### PR TITLE
Add cast serial tests on kittchensink node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,6 +2371,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
+ "serial_test 2.0.0",
  "tempfile",
  "tikv-jemallocator",
  "tokio",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -87,6 +87,7 @@ tikv-jemallocator = { workspace = true, optional = true }
 [dev-dependencies]
 anvil.workspace = true
 foundry-test-utils.workspace = true
+serial_test = "2.0"
 
 [features]
 default = ["jemalloc"]

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -21,6 +21,18 @@ extern crate foundry_test_utils;
 
 mod selectors;
 
+mod revive_chain;
+
+mod revive_transactions;
+
+mod revive_block;
+
+mod revive_accounts;
+
+mod revive_wallet;
+
+mod revive_abi_commands;
+
 casttest!(print_short_version, |_prj, cmd| {
     cmd.arg("-V").assert_success().stdout_eq(str![[r#"
 cast [..]-[..] ([..] [..])

--- a/crates/cast/tests/cli/revive_abi_commands.rs
+++ b/crates/cast/tests/cli/revive_abi_commands.rs
@@ -1,0 +1,113 @@
+use foundry_test_utils::{casttest, util::OutputExt};
+
+casttest!(test_abi_encode, async |_prj, cmd| {
+    let out = cmd
+        .cast_fuse()
+        .args(["abi-encode", "foo(uint256)", "1"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    let expected = "0x".to_owned()
+        + "0000000000000000000000000000000000000000000000000000000000000001";
+    assert_eq!(out, expected, "abi-encode uint256 failed");
+});
+
+casttest!(test_cast_sig, |_prj, cmd| {
+    let out = cmd
+        .cast_fuse()
+        .args(["sig", "transfer(address,uint256)"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("0xa9059cbb"), "unexpected selector: {}", out);
+});
+
+casttest!(test_cast_4byte_lookup, |_prj, cmd| {
+    let out = cmd
+        .cast_fuse()
+        .args(["4byte", "0xa9059cbb"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("transfer(address,uint256)"), "unexpected signature: {}", out);
+});
+
+
+casttest!(test_cast_4byte_calldata, |_prj, cmd| {
+    let calldata = "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d00000000000000000000000000000000000000000000000000174b37380cea000";
+    let out = cmd
+        .cast_fuse()
+        .args(["4byte-calldata", calldata])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("transfer(address,uint256)"), "bad signature parse: {}", out);
+});
+
+casttest!(test_cast_4byte_event, |_prj, cmd| {
+    let topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    let out = cmd
+        .cast_fuse()
+        .args(["4byte-event", topic])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(
+        out.contains("Transfer(address,address,uint256)"),
+        "unexpected event signature: {}", out
+    );
+});
+
+casttest!(test_cast_calldata_named, |_prj, cmd| {
+    let sig = "balanceOf(address)";
+    let data = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
+    let out = cmd
+        .cast_fuse()
+        .args(["calldata", sig, data])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("0x70a08231000000000000000000000000a16081f360e3847006db660bae1c6d1b2e17ec2a"), "calldata command failed: {}", out);
+});
+
+casttest!(test_cast_decode_abi, |_prj, cmd| {
+    let types = "transfer(address,uint256)";
+    let data = concat!(
+        "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0000000000000000000000000000000000000000000000000008a8e4b1a3d8000"
+    );
+    let out = cmd
+        .cast_fuse()
+        .args(["decode-abi", "--input", types, data])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("0x00000000E78388B4CE79068E89Bf8AA7F218ef6B"), "command decode-abi failed: {}", out);
+});
+
+casttest!(test_cast_decode_calldata, |_prj, cmd| {
+    let sig = "transfer(address,uint256)";
+    let data = concat!(
+        "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0000000000000000000000000000000000000000000000000008a8e4b1a3d8000"
+    );
+    let out = cmd
+        .cast_fuse()
+        .args(["decode-calldata", sig, data])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(out.contains("0xE78388b4CE79068e89Bf8aA7f218eF6b9AB0e9d0"), "command decode-calldata failed - : {}", out);
+});
+
+casttest!(test_cast_upload_signature, |_prj, cmd| {
+    let out = cmd.cast_fuse()
+        .args(["upload-signature", "spam(uint256,address)"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(out.contains("spam(uint256,address)"), "missing signature name: {}", out);
+    assert!(out.contains("Selectors successfully uploaded") || out.contains("Duplicated"), "unexpected upload result: {}", out);
+});

--- a/crates/cast/tests/cli/revive_accounts.rs
+++ b/crates/cast/tests/cli/revive_accounts.rs
@@ -1,0 +1,121 @@
+use foundry_test_utils::{
+    casttest,
+    revive::PolkadotNode,
+    util::OutputExt,
+};
+use serial_test::serial;
+
+casttest!(#[serial] test_cast_balance, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.unwrap();
+    let url   = PolkadotNode::http_endpoint();
+
+    let (account, _) = PolkadotNode::dev_accounts()
+        .next()
+        .expect("no dev accounts available");
+    let account = account.to_string();
+
+    let bal = cmd
+        .cast_fuse()
+        .args(["balance", "--rpc-url", url, &account])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // wei equivalent    
+    assert!(
+        bal.parse::<u128>().is_ok(),
+        "balance wasn’t a valid integer: `{}`",
+        bal
+    );
+});
+
+casttest!(#[serial] test_cast_nonce, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.unwrap();
+    let url   = PolkadotNode::http_endpoint();
+    let (account, _) = PolkadotNode::dev_accounts().next().unwrap();
+    let account = account.to_string();
+
+    let nonce = cmd
+        .cast_fuse()
+        .args(["nonce", "--rpc-url", url, &account])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(
+        nonce.parse::<u64>().is_ok(),
+        "nonce wasn’t a valid integer: `{}`",
+        nonce
+    );
+});
+
+casttest!(#[serial] test_cast_code, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.unwrap();
+    let url   = PolkadotNode::http_endpoint();
+    let (account, _) = PolkadotNode::dev_accounts().next().unwrap();
+    let account = account.to_string();
+
+    let code = cmd
+        .cast_fuse()
+        .args(["code", "--rpc-url", url, &account])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // Non‐contract accounts return "0x"
+    assert!(
+        code == "0x" || code.starts_with("0x"),
+        "code should be hex, got `{}`",
+        code
+    );
+});
+
+casttest!(#[serial] test_cast_codesize, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.unwrap();
+    let url   = PolkadotNode::http_endpoint();
+    let (account, _) = PolkadotNode::dev_accounts().next().unwrap();
+    let account = account.to_string();
+
+    let size = cmd
+        .cast_fuse()
+        .args(["codesize", "--rpc-url", url, &account])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(
+        size.parse::<u64>().is_ok(),
+        "codesize wasn’t a valid integer: `{}`",
+        size
+    );
+});
+
+casttest!(#[serial] test_cast_storage, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.unwrap();
+    let url   = PolkadotNode::http_endpoint();
+    let (account, _) = PolkadotNode::dev_accounts().next().unwrap();
+    let account = account.to_string();
+
+    let val = cmd
+        .cast_fuse()
+        .args(["storage", "--rpc-url", url, &account, "0x0"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(
+        val.starts_with("0x"),
+        "storage didn’t return hex: `{}`",
+        val
+    );
+});

--- a/crates/cast/tests/cli/revive_block.rs
+++ b/crates/cast/tests/cli/revive_block.rs
@@ -1,0 +1,129 @@
+use foundry_test_utils::{casttest, revive::PolkadotNode, util::OutputExt};
+use serial_test::serial;
+
+
+casttest!(#[serial] test_cast_block_number, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+    let bn = cmd
+        .cast_fuse()
+        .args(["block-number", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(bn.parse::<u64>().is_ok(), "block-number output not a valid integer: `{}`", bn);
+});
+
+casttest!(#[serial] test_cast_gas_price, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+
+    let gp = cmd
+        .cast_fuse()
+        .args(["gas-price", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(gp.parse::<u128>().is_ok(), "gas-price output not a valid integer: `{}`", gp);
+});
+
+casttest!(#[serial] test_cast_basefee, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+
+    let bf = cmd
+        .cast_fuse()
+        .args(["basefee", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(bf.parse::<u128>().is_ok(), "basefee output not a valid integer: `{}`", bf);
+});
+
+casttest!(#[serial] test_cast_block, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+
+    let info = cmd
+        .cast_fuse()
+        .args(["block", "latest", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .to_lowercase();
+
+    assert!(
+        info.contains("number") && info.contains("hash"),
+        "block info missing fields: `{}`",
+        info
+    );
+});
+
+casttest!(#[serial] test_cast_age, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+
+    let age = cmd
+        .cast_fuse()
+        .args(["age", "latest", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(age.ends_with("UTC"), "age output not a human timestamp ending in UTC: `{}`", age);
+});
+
+casttest!(#[serial] test_cast_find_block, async |_prj, cmd| {
+    let _node = PolkadotNode::start().await.expect("failed to start node");
+    let url = PolkadotNode::http_endpoint();
+
+    let bn = cmd
+        .cast_fuse()
+        .args(["block-number", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .parse::<u64>()
+        .unwrap();
+
+    let ts_hex = cmd
+        .cast_fuse()
+        .args(["block", "latest", "-f", "timestamp", "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    let ts = u64::from_str_radix(ts_hex.trim_start_matches("0x"), 16).unwrap();
+
+    let fb = cmd
+        .cast_fuse()
+        .args(["find-block", &ts.to_string(), "--rpc-url", url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .parse::<u64>()
+        .unwrap();
+
+    assert!(
+        fb <= bn,
+        "find-block({}) returned {}, which is > latest block-number ({})",
+        ts,
+        fb,
+        bn
+    );
+});

--- a/crates/cast/tests/cli/revive_chain.rs
+++ b/crates/cast/tests/cli/revive_chain.rs
@@ -1,0 +1,60 @@
+use foundry_test_utils::{
+    casttest,
+    revive::PolkadotNode,
+    util::OutputExt,
+};
+
+casttest!(test_cast_chain_id, async |_prj, cmd| {
+    let _node   = PolkadotNode::start().await.expect("failed to start node");
+    let rpc_url = PolkadotNode::http_endpoint();
+    let id = cmd
+        .cast_fuse()
+        .args(["chain-id", "--rpc-url", &rpc_url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(
+        id.parse::<u64>().is_ok(),
+        "chain-id wasn’t a number: {id}"
+    );
+});
+
+casttest!(test_cast_chain, async |_prj, cmd| {
+    let _node   = PolkadotNode::start().await.expect("failed to start node");
+    let rpc_url = PolkadotNode::http_endpoint();
+    let name = cmd
+        .cast_fuse()
+        .args(["chain", "--rpc-url", &rpc_url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert_eq!(
+        name,
+        "unknown",
+        "cast chain should return \"unknown\" for an unrecognized chain ID"
+    );
+});
+
+casttest!(test_cast_client, async |_prj, cmd| {
+    let _node   = PolkadotNode::start().await.expect("failed to start node");
+    let rpc_url = PolkadotNode::http_endpoint();
+    let version = cmd
+        .cast_fuse()
+        .args(["client", "--rpc-url", &rpc_url])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    assert!(
+        !version.is_empty(),
+        "Expected non-empty client version, got `{version}`"
+    );
+});

--- a/crates/cast/tests/cli/revive_wallet.rs
+++ b/crates/cast/tests/cli/revive_wallet.rs
@@ -1,0 +1,154 @@
+use foundry_test_utils::{casttest, util::OutputExt};
+use serial_test::serial;
+use std::{fs, path::Path};
+use tempfile::TempDir;
+
+casttest!(
+    #[serial]
+    test_cast_wallet_new,
+    async |_prj, cmd| {
+        let tmp = TempDir::new().expect("tmpdir");
+        let dir = tmp.path().to_str().unwrap();
+
+        let stdout = cmd
+            .cast_fuse()
+            .args(["wallet", "new", "--unsafe-password", "testpass", dir])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+
+        let first_line = stdout.lines().next().expect("no output from wallet new");
+        let prefix = "Created new encrypted keystore file: ";
+        let path =
+            first_line.strip_prefix(prefix).expect("unexpected output format for wallet new");
+
+        assert!(Path::new(path).exists(), "keystore file was not created: {}", path);
+    }
+);
+
+casttest!(
+    #[serial]
+    test_cast_wallet_address,
+    async |_prj, cmd| {
+
+        let pk = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        let addr = cmd
+            .cast_fuse()
+            .args(["wallet", "address", "--private-key", pk])
+            .assert_success()
+            .get_output()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        assert!(
+            addr.starts_with("0x") && addr.len() == 42,
+            "wallet address has wrong format: {}",
+            addr
+        );
+
+        assert!(
+            addr.chars().skip(2).all(|c| c.is_ascii_hexdigit()),
+            "address contains non-hex character: {}",
+            addr
+        );
+    }
+);
+
+casttest!(
+    #[serial]
+    test_cast_wallet_list,
+    async |_prj, cmd| {
+
+        let tmp = TempDir::new().expect("tmpdir");
+        let home = tmp.path();
+
+        fs::create_dir_all(home.join("keystore")).expect("couldn’t create keystore dir");
+        cmd.env("FOUNDRY_HOME", home.to_str().unwrap());
+
+
+        let out = cmd
+            .cast_fuse()
+            .args(["wallet", "list"])
+            .assert_success()
+            .get_output()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        assert!(
+            out.contains("(Local)"),
+            "expected to see the built-in Local account, got `{}`",
+            out
+        );
+    }
+);
+
+casttest!(
+    #[serial]
+    test_cast_wallet_import,
+    async |_prj, cmd| {
+
+        let tmp = TempDir::new().unwrap();
+        let keystore_dir = tmp.path().join("keystore");
+        fs::create_dir_all(&keystore_dir).unwrap();
+        let dir_arg = keystore_dir.to_str().unwrap();
+
+        let dummy_pk = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        let out = cmd
+            .cast_fuse()
+            .args(&[
+                "wallet",
+                "import",
+                "--private-key",
+                dummy_pk,
+                "--unsafe-password",
+                "testpass",
+                "--keystore-dir",
+                dir_arg,
+                "foo",
+            ])
+            .assert_success()
+            .get_output()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        assert!(
+            out.contains("`foo` keystore was saved successfully"),
+            "`foo` keystore was not saved successfully"
+        );
+    }
+);
+
+casttest!(
+    #[serial]
+    test_cast_wallet_sign_verify,
+    async |_prj, cmd| {
+        let pk = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let address = cmd
+            .cast_fuse()
+            .args(["wallet", "address", "--private-key", pk])
+            .assert_success()
+            .get_output()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        let msg = "hello, world";
+        let sig = cmd
+            .cast_fuse()
+            .args(["wallet", "sign", "--private-key", pk, msg])
+            .assert_success()
+            .get_output()
+            .stdout_lossy()
+            .trim()
+            .to_string();
+
+        cmd.cast_fuse()
+            .args(&["wallet", "verify", "--address", &address, msg, &sig])
+            .assert_success();
+    }
+);


### PR DESCRIPTION
## Motivation

<!--
The solution for the ticket [Add Cast tests in kitchen sink node](https://github.com/paritytech/foundry-polkadot/issues/82)
-->

## Solution

<!--
Created multiple cast subcommands tests
-->

`Cast chain tests`

`adp@Ashishs-MacBook-Pro-2 foundry-revive % cargo test --package cast --test cli -- revive_chain —exact --show-output       

   Compiling cast v1.1.0 (/Users/adp/Documents/workspace/foundry-revive/crates/cast)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.36s
     Running tests/cli/main.rs (target/debug/deps/cli-a4aa30108d1567a0)

running 3 tests 
test revive_chain::test_cast_chain_id ... ok
test revive_chain::test_cast_client ... ok
test revive_chain::test_cast_chain ... ok

successes:

---- revive_chain::test_cast_chain_id stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "chain-id" "--rpc-url" "http://127.0.0.1:8545"

---- revive_chain::test_cast_client stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "client" "--rpc-url" "http://127.0.0.1:8545"

---- revive_chain::test_cast_chain stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "chain" "--rpc-url" "http://127.0.0.1:8545"


successes:
    revive_chain::test_cast_chain
    revive_chain::test_cast_chain_id
    revive_chain::test_cast_client

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 136 filtered out; finished in 15.47s`

-----------------------------------------------------------------------------------------------------------------------

`Cast abi_commands tests`

`adp@Ashishs-MacBook-Pro-2 foundry-revive % cargo test --package cast --test cli -- revive_abi_commands —exact --show-output

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.92s
     Running tests/cli/main.rs (target/debug/deps/cli-a4aa30108d1567a0)

running 9 tests
test revive_abi_commands::test_cast_decode_calldata ... ok
test revive_abi_commands::test_cast_calldata_named ... ok
test revive_abi_commands::test_cast_decode_abi ... ok
test revive_abi_commands::test_cast_sig ... ok
test revive_abi_commands::test_abi_encode ... ok
test revive_abi_commands::test_cast_upload_signature ... ok
test revive_abi_commands::test_cast_4byte_event ... ok
test revive_abi_commands::test_cast_4byte_lookup ... ok
test revive_abi_commands::test_cast_4byte_calldata ... ok

successes:

---- revive_abi_commands::test_cast_decode_calldata stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "decode-calldata" "transfer(address,uint256)" "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0000000000000000000000000000000000000000000000000008a8e4b1a3d8000"

---- revive_abi_commands::test_cast_calldata_named stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "calldata" "balanceOf(address)" "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"

---- revive_abi_commands::test_cast_decode_abi stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "decode-abi" "--input" "transfer(address,uint256)" "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0000000000000000000000000000000000000000000000000008a8e4b1a3d8000"

---- revive_abi_commands::test_cast_sig stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "sig" "transfer(address,uint256)"

---- revive_abi_commands::test_abi_encode stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "abi-encode" "foo(uint256)" "1"

---- revive_abi_commands::test_cast_upload_signature stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "upload-signature" "spam(uint256,address)"

---- revive_abi_commands::test_cast_4byte_event stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "4byte-event" "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"

---- revive_abi_commands::test_cast_4byte_lookup stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "4byte" "0xa9059cbb"

---- revive_abi_commands::test_cast_4byte_calldata stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "4byte-calldata" "0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d00000000000000000000000000000000000000000000000000174b37380cea000"


successes:
    revive_abi_commands::test_abi_encode
    revive_abi_commands::test_cast_4byte_calldata
    revive_abi_commands::test_cast_4byte_event
    revive_abi_commands::test_cast_4byte_lookup
    revive_abi_commands::test_cast_calldata_named
    revive_abi_commands::test_cast_decode_abi
    revive_abi_commands::test_cast_decode_calldata
    revive_abi_commands::test_cast_sig
    revive_abi_commands::test_cast_upload_signature

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 130 filtered out; finished in 2.46s
`

----------------------------------------------------------------------------------------------------------------------------

`Cast wallet tests`

`adp@Ashishs-MacBook-Pro-2 foundry-revive % cargo test --package cast --test cli -- revive_wallet —exact --show-output      

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.49s
     Running tests/cli/main.rs (target/debug/deps/cli-a4aa30108d1567a0)

running 5 tests
test revive_wallet::test_cast_wallet_import ... ok
test revive_wallet::test_cast_wallet_list ... ok
test revive_wallet::test_cast_wallet_new ... ok
test revive_wallet::test_cast_wallet_address ... ok
test revive_wallet::test_cast_wallet_sign_verify ... ok

successes:

---- revive_wallet::test_cast_wallet_import stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "import" "--private-key" "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "--unsafe-password" "testpass" "--keystore-dir" "/var/folders/5h/vpdddj4s5t5gg1q6t5r3cv540000gn/T/.tmppLXMIk/keystore" "foo"

---- revive_wallet::test_cast_wallet_list stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "list"

---- revive_wallet::test_cast_wallet_new stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "new" "--unsafe-password" "testpass" "/var/folders/5h/vpdddj4s5t5gg1q6t5r3cv540000gn/T/.tmpPh35gz"

---- revive_wallet::test_cast_wallet_address stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "address" "--private-key" "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"

---- revive_wallet::test_cast_wallet_sign_verify stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "address" "--private-key" "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "sign" "--private-key" "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" "hello, world"
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "wallet" "verify" "--address" "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c" "hello, world" "0x51d5d69f60298048918442b839292e5024a43c35f1c7d94cc38dbf9a2f7b3c216fc6101c36a7127be76bc91b81fb9c1fea06fe285367098fd8eee4d0931e38b31c"


successes:
    revive_wallet::test_cast_wallet_address
    revive_wallet::test_cast_wallet_import
    revive_wallet::test_cast_wallet_list
    revive_wallet::test_cast_wallet_new
    revive_wallet::test_cast_wallet_sign_verify

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 1.55s`

---------------------------------------------------------------------------------------------------------------------------

`cast block tests`

`adp@Ashishs-MacBook-Pro-2 foundry-revive % cargo test --package cast --test cli -- revive_block —exact --show-output      

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.95s
     Running tests/cli/main.rs (target/debug/deps/cli-a4aa30108d1567a0)

running 6 tests
test revive_block::test_cast_gas_price ... ok
test revive_block::test_cast_block_number ... ok
test revive_block::test_cast_basefee ... ok
test revive_block::test_cast_age ... ok
test revive_block::test_cast_find_block ... ok
test revive_block::test_cast_block ... ok

successes:

---- revive_block::test_cast_gas_price stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "gas-price" "--rpc-url" "http://127.0.0.1:8545"

---- revive_block::test_cast_block_number stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "block-number" "--rpc-url" "http://127.0.0.1:8545"

---- revive_block::test_cast_basefee stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "basefee" "--rpc-url" "http://127.0.0.1:8545"

---- revive_block::test_cast_age stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "age" "latest" "--rpc-url" "http://127.0.0.1:8545"

---- revive_block::test_cast_find_block stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "block-number" "--rpc-url" "http://127.0.0.1:8545"
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "block" "latest" "-f" "timestamp" "--rpc-url" "http://127.0.0.1:8545"
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "find-block" "99948574726" "--rpc-url" "http://127.0.0.1:8545"

---- revive_block::test_cast_block stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "block" "latest" "--rpc-url" "http://127.0.0.1:8545"


successes:
    revive_block::test_cast_age
    revive_block::test_cast_basefee
    revive_block::test_cast_block
    revive_block::test_cast_block_number
    revive_block::test_cast_find_block
    revive_block::test_cast_gas_price

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 133 filtered out; finished in 44.40s`


---------------------------------------------------------------------------------------------------------------------------

`cast account tests`

`adp@Ashishs-MacBook-Pro-2 foundry-revive % cargo test --package cast --test cli -- revive_accounts —exact --show-output

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.91s
     Running tests/cli/main.rs (target/debug/deps/cli-85a88489a618f9ec)

running 5 tests
test revive_accounts::test_cast_balance ... ok
test revive_accounts::test_cast_code ... ok
test revive_accounts::test_cast_codesize ... ok
test revive_accounts::test_cast_nonce ... ok
test revive_accounts::test_cast_storage ... ok

successes:

---- revive_accounts::test_cast_balance stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "balance" "--rpc-url" "http://127.0.0.1:8545" "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"

---- revive_accounts::test_cast_code stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "code" "--rpc-url" "http://127.0.0.1:8545" "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"

---- revive_accounts::test_cast_codesize stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "codesize" "--rpc-url" "http://127.0.0.1:8545" "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"

---- revive_accounts::test_cast_nonce stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "nonce" "--rpc-url" "http://127.0.0.1:8545" "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"

---- revive_accounts::test_cast_storage stdout ----
executing NO_COLOR="1" "/Users/adp/Documents/workspace/foundry-revive/target/debug/cast" "storage" "--rpc-url" "http://127.0.0.1:8545" "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac" "0x0"


successes:
    revive_accounts::test_cast_balance
    revive_accounts::test_cast_code
    revive_accounts::test_cast_codesize
    revive_accounts::test_cast_nonce
    revive_accounts::test_cast_storage

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 37.10s

adp@Ashishs-MacBook-Pro-2 foundry-revive % `

## PR Checklist

- [Y] Added Tests
- [ N] Breaking changes