### PR TITLE
Fix `forge bind` with `--resolc`

### DIFF
--- a/crates/config/src/revive.rs
+++ b/crates/config/src/revive.rs
@@ -6,9 +6,6 @@ use crate::{Config, SolcReq};
 /// Filename for resolc cache
 pub const RESOLC_SOLIDITY_FILES_CACHE_FILENAME: &str = "resolc-solidity-files-cache.json";
 
-/// Directory for resolc artifacts
-pub const RESOLC_ARTIFACTS_DIR: &str = "resolc-out";
-
 pub const CONTRACT_SIZE_LIMIT: usize = 250_000;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -29,7 +26,6 @@ impl ResolcConfig {
             .sources(&config.src)
             .tests(&config.test)
             .scripts(&config.script)
-            .artifacts(config.root.join(RESOLC_ARTIFACTS_DIR))
             .libs(config.libs.iter())
             .remappings(config.get_all_remappings())
             .allowed_path(&config.root)

--- a/crates/config/src/revive.rs
+++ b/crates/config/src/revive.rs
@@ -43,7 +43,8 @@ impl ResolcConfig {
             .allowed_path(&config.root)
             .allowed_paths(&config.libs)
             .allowed_paths(&config.allow_paths)
-            .include_paths(&config.include_paths);
+            .include_paths(&config.include_paths)
+            .artifacts(&config.out);
 
         builder.build_with_root(&config.root)
     }

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -105,13 +105,9 @@ pub fn run_command(args: Forge) -> Result<()> {
             Ok(())
         }
         ForgeSubcommand::Clean { root } => {
-            let mut config = utils::load_config_with_root(root.as_deref())?;
+            let config = utils::load_config_with_root(root.as_deref())?;
             let project = config.project()?;
             config.cleanup(&project)?;
-
-            config.resolc.resolc_compile = true;
-            let resolc_project = config.project()?;
-            config.cleanup(&resolc_project)?;
 
             Ok(())
         }

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -123,7 +123,9 @@ impl BindArgs {
         }
 
         let config = self.load_config()?;
-        let artifacts = config.out;
+        let project = config.project()?;
+
+        let artifacts = { project.artifacts_path() };
         let bindings_root = self.bindings.clone().unwrap_or_else(|| artifacts.join("bindings"));
 
         if bindings_root.exists() {

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -120,7 +120,7 @@ impl BindArgs {
         if !self.skip_build {
             let project = self.build.project()?;
             let old_builds: BTreeSet<String> = {
-                if let Some(entries) = std::fs::read_dir(&project.paths.build_infos).ok() {
+                if let Ok(entries) = std::fs::read_dir(&project.paths.build_infos) {
                     entries
                         .filter_map(|x| x.ok())
                         .filter_map(|f| {

--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -125,20 +125,20 @@ impl BindArgs {
         let config = self.load_config()?;
         let project = config.project()?;
 
-        let artifacts = { project.artifacts_path() };
+        let artifacts = project.artifacts_path();
         let bindings_root = self.bindings.clone().unwrap_or_else(|| artifacts.join("bindings"));
 
         if bindings_root.exists() {
             if !self.overwrite {
                 sh_println!("Bindings found. Checking for consistency.")?;
-                return self.check_existing_bindings(&artifacts, &bindings_root);
+                return self.check_existing_bindings(artifacts, &bindings_root);
             }
 
             trace!(?artifacts, "Removing existing bindings");
             fs::remove_dir_all(&bindings_root)?;
         }
 
-        self.generate_bindings(&artifacts, &bindings_root)?;
+        self.generate_bindings(artifacts, &bindings_root)?;
 
         sh_println!("Bindings have been generated to {}", bindings_root.display())?;
         Ok(())

--- a/crates/forge/tests/cli/revive_cmd.rs
+++ b/crates/forge/tests/cli/revive_cmd.rs
@@ -892,7 +892,6 @@ forgetest!(inspect_custom_counter_method_identifiers_for_resolc, |prj, cmd| {
 forgetest!(can_bind_for_resolc, |prj, cmd| {
     init_prj(&prj);
 
-    //TODO: bind command is looking for artifacts in wrong directory
     cmd.args(["bind", "--resolc"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [RESOLC_VERSION]
 [RESOLC_VERSION] [ELAPSED]

--- a/crates/forge/tests/cli/revive_cmd.rs
+++ b/crates/forge/tests/cli/revive_cmd.rs
@@ -893,7 +893,7 @@ forgetest!(can_bind_for_resolc, |prj, cmd| {
     init_prj(&prj);
 
     //TODO: bind command is looking for artifacts in wrong directory
-    cmd.args(["bind", "--resolc", "--out", "resolc-out"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["bind", "--resolc"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [RESOLC_VERSION]
 [RESOLC_VERSION] [ELAPSED]
 Compiler run successful!

--- a/crates/forge/tests/cli/revive_cmd.rs
+++ b/crates/forge/tests/cli/revive_cmd.rs
@@ -25,7 +25,7 @@ forgetest_init!(can_clean_config, |prj, cmd| {
     // prj.update_config(|config| config.out = "custom-out".into());
     cmd.args(["build", "--resolc"]).assert_success();
 
-    let artifact = prj.root().join(format!("resolc-out/{TEMPLATE_TEST_CONTRACT_ARTIFACT_JSON}"));
+    let artifact = prj.artifacts().join(TEMPLATE_TEST_CONTRACT_ARTIFACT_JSON);
     assert!(artifact.exists());
 
     cmd.forge_fuse().arg("clean").assert_empty_stdout();
@@ -43,14 +43,14 @@ contract Foo {}
     .unwrap();
 
     // compile with solc
-    cmd.args(["build", "--out=resolc-out"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["build"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
 "#]]);
 
-    let artifact = prj.root().join("resolc-out/");
+    let artifact = prj.artifacts();
     assert!(artifact.exists());
 
     // compile with resolc to the same output dir (resolc has hardcoded output dir)
@@ -62,7 +62,7 @@ Compiler run successful!
 "#]]);
 
     // compile again with solc to the same output dir
-    cmd.forge_fuse().args(["build", "--out=resolc-out"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().args(["build"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -84,7 +84,7 @@ Compiler run successful!
 "#]
     ]);
 
-    let artifact_path = prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_JSON}"));
+    let artifact_path = prj.artifacts().join(CONTRACT_ARTIFACT_JSON);
     let artifact: ConfigurableContractArtifact =
         foundry_compilers::utils::read_json_file(&artifact_path).unwrap();
     assert!(artifact.metadata.is_some());
@@ -100,8 +100,7 @@ Compiler run successful!
 
 "#]]);
 
-    let metadata_path =
-        prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_BASE}.metadata.json"));
+    let metadata_path = prj.artifacts().join(format!("{CONTRACT_ARTIFACT_BASE}.metadata.json"));
     let _artifact: Metadata = foundry_compilers::utils::read_json_file(&metadata_path).unwrap();
 });
 
@@ -125,7 +124,7 @@ Compiler run successful!
 
 "#]]);
 
-    let artifact_path = prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_JSON}"));
+    let artifact_path = prj.artifacts().join(CONTRACT_ARTIFACT_JSON);
     let artifact: ConfigurableContractArtifact =
         foundry_compilers::utils::read_json_file(&artifact_path).unwrap();
     assert!(artifact.metadata.is_some());
@@ -151,14 +150,13 @@ Compiler run successful!
 
 "#]]);
 
-    let metadata_path =
-        prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_BASE}.metadata.json"));
+    let metadata_path = prj.artifacts().join(format!("{CONTRACT_ARTIFACT_BASE}.metadata.json"));
     let _artifact: Metadata = foundry_compilers::utils::read_json_file(&metadata_path).unwrap();
 
-    let iropt = prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_BASE}.iropt"));
+    let iropt = prj.artifacts().join(format!("{CONTRACT_ARTIFACT_BASE}.iropt"));
     std::fs::read_to_string(iropt).unwrap();
 
-    let ir = prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_BASE}.ir"));
+    let ir = prj.artifacts().join(format!("{CONTRACT_ARTIFACT_BASE}.ir"));
     std::fs::read_to_string(ir).unwrap();
 });
 
@@ -389,7 +387,7 @@ Compiler run successful!
 
 "#]]);
 
-    let artifact = prj.root().join(format!("resolc-out/{CONTRACT_ARTIFACT_JSON}"));
+    let artifact = prj.artifacts().join(CONTRACT_ARTIFACT_JSON);
     assert!(artifact.exists());
     let cache = prj.root().join("cache/resolc-solidity-files-cache.json");
     assert!(cache.exists());
@@ -926,13 +924,13 @@ forgetest!(can_bind_enum_modules_for_resolc, |prj, cmd| {
     .unwrap();
 
     //TODO: bind command is looking for artifacts in wrong directory
-    cmd.args(["bind", "--resolc", "--out", "resolc-out", "--select", "^Enum$"])
-        .assert_success()
-        .stdout_eq(str![[r#"[COMPILING_FILES] with [RESOLC_VERSION]
+    cmd.args(["bind", "--resolc", "--select", "^Enum$"]).assert_success().stdout_eq(str![[
+        r#"[COMPILING_FILES] with [RESOLC_VERSION]
 [RESOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Generating bindings for 1 contracts
-Bindings have been generated to [..]"#]]);
+Bindings have been generated to [..]"#
+    ]]);
 });
 
 // Tests that direct import paths are handled correctly


### PR DESCRIPTION
### Description 

Will use correct artifact.paths() for a given project now and look for artifacts in a correct directory. 

Related to #119 