### PR TITLE
Fix `forge compiler resolve` to accept `ResolcArgs`

### DIFF
--- a/crates/cli/src/opts/build/revive.rs
+++ b/crates/cli/src/opts/build/revive.rs
@@ -56,8 +56,7 @@ pub struct ResolcOpts {
 }
 
 impl ResolcOpts {
-    /// Applies overrides if they are present
-    pub fn apply_overrides(&self, mut resolc: ResolcConfig) -> ResolcConfig {
+    pub(crate) fn apply_overrides(&self, mut resolc: ResolcConfig) -> ResolcConfig {
         macro_rules! set_if_some {
             ($src:expr, $dst:expr) => {
                 if let Some(src) = $src {

--- a/crates/forge/tests/cli/revive_compiler.rs
+++ b/crates/forge/tests/cli/revive_compiler.rs
@@ -36,12 +36,11 @@ forgetest!(can_resolve_path, |prj, cmd| {
         config.resolc.resolc = Some(foundry_config::SolcReq::Version(
             semver::Version::parse(OTHER_RESOLC_VERSION).unwrap(),
         ));
-        config.resolc.resolc_compile = true;
     });
 
     prj.add_source("ContractA", CONTRACT_A).unwrap();
 
-    cmd.args(["compiler", "resolve", "--root", prj.root().to_str().unwrap()])
+    cmd.args(["compiler", "resolve", "--resolc", "--root", prj.root().to_str().unwrap()])
         .assert_success()
         .stdout_eq(str![[r#"
 Solidity:


### PR DESCRIPTION
### Description 

`forge compiler resolve` now accepts `ResolcArgs` 