### PR TITLE
Updated CHANGELOG.md for v.1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Improved CI and use dRPC service (#67) (Sebastian Miasojed) - 2025-03-25
 
 ### Fixed
-- Fixed `forge compiler resolc` to accept `ResolcArgs` (#142) (Pavlo Khrystenko) - 2025-05-29
+- Fixed `forge compiler resolve` to accept `ResolcArgs` (#142) (Pavlo Khrystenko) - 2025-05-29
 - Fixed the resolc config option propagation (#135) (Sebastian Miasojed) - 2025-05-22
 - Fixed `forge bind` with `--resolc` (#132) (Pavlo Khrystenko) - 2025-05-21
 - Fixed clippy CI issue (#94) (Pavlo Khrystenko) - 2025-04-24


### PR DESCRIPTION
### TL;DR
This pull request updates the `CHANGELOG.md` to document all important changes included in the `v1.1.0` release, covering the period from _March 25, 2025_ (around the first fork commits on our end), onward. I tried to follow the good practices so the `CHANGELOG.md` now follows best practices, including:
- categorized entries: `Added`, `Changed`, `Fixed`, `Infrastructure`, and `Documentation`.
- detailed entries: each entry includes a clear description, pull request number, author, and the date the change was merged.
- chronological order: entries are listed in the order they were merged for better traceability.