### PR TITLE
[issues/228] Implemented `CALL` execution on PVM

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1218,6 +1218,10 @@ where {
             }]);
         }
 
+        if let Some(result) = self.strategy.runner.revive_try_call(self, ecx, call, executor) {
+            return Some(result);
+        }
+
         None
     }
 

--- a/crates/cheatcodes/src/strategy.rs
+++ b/crates/cheatcodes/src/strategy.rs
@@ -229,6 +229,16 @@ pub trait CheatcodeInspectorStrategyExt {
     ) -> Option<revm::interpreter::CreateOutcome> {
         None
     }
+
+    fn revive_try_call(
+        &self,
+        _state: &mut crate::Cheatcodes,
+        _ecx: InnerEcx,
+        _input: &CallInputs,
+        _executor: &mut dyn CheatcodesExecutor,
+    ) -> Option<revm::interpreter::CallOutcome> {
+        None
+    }
 }
 
 // Legacy type aliases for backward compatibility

--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -438,7 +438,8 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
             .db
             .get_test_contract_address()
             .map(|addr| call.bytecode_address == addr)
-            .unwrap_or_default() {
+            .unwrap_or_default()
+        {
             tracing::info!(
                 "running call in EVM, instead of PVM (Test Contract) {:#?}",
                 call.bytecode_address

--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -434,7 +434,11 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
             return None;
         }
 
-        if ecx.db.get_test_contract_address().map(|addr| call.bytecode_address == addr).unwrap_or_default() {
+        if ecx
+            .db
+            .get_test_contract_address()
+            .map(|addr| call.bytecode_address == addr)
+            .unwrap_or_default() {
             tracing::info!(
                 "running call in EVM, instead of PVM (Test Contract) {:#?}",
                 call.bytecode_address

--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -30,7 +30,7 @@ use polkadot_sdk::{
 
 use revm::{
     interpreter::{
-        opcode as op, CallInputs, CreateOutcome, Gas, InstructionResult, Interpreter,
+        opcode as op, CallInputs, CallOutcome, CreateOutcome, Gas, InstructionResult, Interpreter,
         InterpreterResult,
     },
     primitives::{CreateScheme, SignedAuthorization},
@@ -412,6 +412,114 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
                         gas,
                     },
                     address: None,
+                })
+            }
+        }
+    }
+
+    /// Try handling the `CALL` within PVM.
+    ///
+    /// If `Some` is returned then the result must be returned immediately, else the call must be
+    /// handled in EVM.
+    fn revive_try_call(
+        &self,
+        state: &mut foundry_cheatcodes::Cheatcodes,
+        ecx: InnerEcx<'_, '_, '_>,
+        call: &CallInputs,
+        _executor: &mut dyn foundry_cheatcodes::CheatcodesExecutor,
+    ) -> Option<CallOutcome> {
+        let ctx = get_context_ref_mut(state.strategy.context.as_mut());
+
+        if !ctx.using_pvm {
+            return None;
+        }
+
+        if ecx.db.get_test_contract_address().map(|addr| call.bytecode_address == addr).unwrap_or_default() {
+            tracing::info!(
+                "running call in EVM, instead of PVM (Test Contract) {:#?}",
+                call.bytecode_address
+            );
+            return None;
+        }
+
+        tracing::info!("running call in PVM {:#?}", call);
+
+        let max_gas =
+            <<Runtime as Config>::EthGasEncoder as GasEncoder<BalanceOf<Runtime>>>::encode(
+                Default::default(),
+                Weight::MAX,
+                1u128 << 99,
+            );
+        let gas_limit = sp_core::U256::from(call.gas_limit).min(max_gas);
+
+        let res = ctx.revive_test_externalities.lock().unwrap().execute_with(|| {
+            let origin = OriginFor::<Runtime>::signed(AccountId::to_fallback_account_id(
+                &H160::from_slice(call.caller.as_slice()),
+            ));
+            let evm_value = sp_core::U256::from_little_endian(&call.call_value().as_le_bytes());
+
+            let (gas_limit, storage_deposit_limit) =
+                <<Runtime as Config>::EthGasEncoder as GasEncoder<BalanceOf<Runtime>>>::decode(
+                    gas_limit,
+                )
+                .expect("gas limit is valid");
+            let storage_deposit_limit = DepositLimit::Balance(storage_deposit_limit);
+            let target = H160::from_slice(call.target_address.as_slice());
+
+            Pallet::<Runtime>::bare_call(
+                origin,
+                target,
+                evm_value,
+                gas_limit,
+                storage_deposit_limit,
+                call.input.to_vec(),
+            )
+        });
+
+        let mut gas = Gas::new(call.gas_limit);
+        let gas_used =
+            <<Runtime as Config>::EthGasEncoder as GasEncoder<BalanceOf<Runtime>>>::encode(
+                gas_limit,
+                res.gas_required,
+                res.storage_deposit.charge_or_zero(),
+            );
+        match res.result {
+            Ok(result) => {
+                let _ = gas.record_cost(gas_used.as_u64());
+
+                let outcome = if result.did_revert() {
+                    CallOutcome {
+                        result: InterpreterResult {
+                            result: InstructionResult::Revert,
+                            output: result.data.into(),
+                            gas,
+                        },
+                        memory_offset: call.return_memory_offset.clone(),
+                    }
+                } else {
+                    CallOutcome {
+                        result: InterpreterResult {
+                            result: InstructionResult::Return,
+                            output: result.data.into(),
+                            gas,
+                        },
+                        memory_offset: call.return_memory_offset.clone(),
+                    }
+                };
+
+                Some(outcome)
+            }
+            Err(e) => {
+                tracing::error!("Contract call failed: {e:#?}");
+                Some(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: Bytes::from_iter(
+                            format!("Contract call failed: {e:#?}").as_bytes(),
+                        ),
+                        gas,
+                    },
+                    memory_offset: call.return_memory_offset.clone(),
                 })
             }
         }


### PR DESCRIPTION
#### TL;DR

This pull request implements `CALL` execution on `PVM` in `polkadot-foundry`, following the same pattern as the existing `CREATE` implementation and [zksync_try_call](https://github.com/matter-labs/foundry-zksync/blob/main/crates/strategy/zksync/src/cheatcode/runner/mod.rs#L776) from `foundry-zksync`.

#### Changes
- **Strategy Trait**: Added `revive_try_call` method to `CheatcodeInspectorStrategyExt`
- **Inspector Integration**: Added `PVM` `CALL` handling in `call_with_executor` method
- **PVM Implementation**: Implemented `revive_try_call` in `PvmCheatcodeInspectorStrategyRunner`

#### Implementation Details
- `PVM` mode check with fallback to `EVM` for test contracts
- Storage deposit limit handling via `DepositLimit::Balance`
- Direct integration with `pallet_revive::Pallet::<Runtime>::bare_call`