### PR TITLE
run cheats tests with both resolc and evm enabled

### DIFF
--- a/crates/forge/tests/it/cheats.rs
+++ b/crates/forge/tests/it/cheats.rs
@@ -3,8 +3,9 @@
 use crate::{
     config::*,
     test_helpers::{
-        ForgeTestData, RE_PATH_SEPARATOR, TEST_DATA_DEFAULT, TEST_DATA_MULTI_VERSION,
-        TEST_DATA_PARIS,
+        ForgeTestData, RE_PATH_SEPARATOR, TEST_DATA_DEFAULT, TEST_DATA_DEFAULT_RESOLC,
+        TEST_DATA_MULTI_VERSION, TEST_DATA_MULTI_VERSION_RESOLC, TEST_DATA_PARIS,
+        TEST_DATA_PARIS_RESOLC,
     },
 };
 use alloy_primitives::U256;
@@ -79,4 +80,29 @@ async fn test_cheats_local_multi_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_local_paris() {
     test_cheats_local(&TEST_DATA_PARIS).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolc_cheats_local_default() {
+    test_cheats_local(&TEST_DATA_DEFAULT_RESOLC).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolc_cheats_local_default_isolated() {
+    test_cheats_local_isolated(&TEST_DATA_DEFAULT_RESOLC).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolc_cheats_local_default_with_seed() {
+    test_cheats_local_with_seed(&TEST_DATA_DEFAULT_RESOLC).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolc_cheats_local_multi_version() {
+    test_cheats_local(&TEST_DATA_MULTI_VERSION_RESOLC).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_resolc_cheats_local_paris() {
+    test_cheats_local(&TEST_DATA_PARIS_RESOLC).await
 }


### PR DESCRIPTION
Make the cheats tests run with both resolc and evm compilers.

Some of the tests have been disabled from compiling because it was failing to compile because of:
## Error 1: solidity version not supported by resolc.
```
Encountered invalid solc version in default/fork/DssExecLib.sol: No solc version exists that matches the version requirement: >=0.6.12, <0.7.0\
```

## Error 2: EXTCODECOPY instruction not supported
```
compiling error: The contract `default/cheats/AttachDelegation.t.sol:AttachDelegationTest` LLVM IR generator definition pass error: 256:25 The `EXTCODECOPY` instruction is not supportedThe contract `default/cheats/AttachDelegation.t.sol:AttachDelegationTest` LLVM IR generator definition pass error: 256:25 The `EXTCODECOPY` instruction is not supported")
```

Note the tests compile with resolc are currently failing, should start passing as more cheat code support is added.
