### PR TITLE
[Forge test][Cheatcodes] `setNonce/getNonce` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15447,6 +15447,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.25",
  "alloy-rpc-types",
+ "alloy-sol-types 0.8.25",
  "eyre",
  "foundry-cheatcodes",
  "foundry-common",

--- a/crates/revive-strategy/Cargo.toml
+++ b/crates/revive-strategy/Cargo.toml
@@ -19,6 +19,7 @@ foundry-cheatcodes.workspace = true
 foundry-linking.workspace = true
 revive-env.workspace = true
 
+alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
 alloy-eips.workspace = true


### PR DESCRIPTION
### Description 

adds `getNonce` and `setNonce` support for test execution using `pallet-revive`. 

`setNonceUnsafe` is still blocked

see #289 #288