### PR TITLE
fixup ubuntu and macos build

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -98,8 +98,10 @@ jobs:
           ./configure --prefix=/usr/local
           make
           sudo make install
-          brew install llvm@20
-          brew link llvm@20
+          brew install llvm
+          brew link llvm
+          export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
+          export LIBCLANG_PATH=$(brew --prefix llvm)/lib
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -224,6 +226,8 @@ jobs:
         run: |
           brew install llvm@20
           brew link llvm@20
+          export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
+          export LIBCLANG_PATH=$(brew --prefix llvm)/lib
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -236,4 +240,7 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           WS_ARCHIVE_URLS: ${{ secrets.WS_ARCHIVE_URLS }}
-        run: cargo nextest run ${{ matrix.flags }}
+        run: |
+          echo "$LLVM_CONFIG_PATH"
+          echo "$LIBCLANG_PATH"
+          cargo nextest run ${{ matrix.flags }}

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Install clang
         id: install-clang
+        if: matrix.os != 'macos'
         uses: egor-tensin/setup-clang@v1
 
           
@@ -211,6 +212,7 @@ jobs:
 
       - name: Install clang
         uses: egor-tensin/setup-clang@v1
+        if: matrix.os != 'macos'
   
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -80,6 +80,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install clang
+        id: install-clang
+        uses: egor-tensin/setup-clang@v1
+
+          
       # macOS-specific setup
       - name: Install libusb 1.0.27 (macOS)
         if: matrix.os == 'macos'
@@ -204,6 +209,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install clang
+        uses: egor-tensin/setup-clang@v1
+  
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -206,7 +206,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          cache-targets: false
+          prefix-key: "v0-rust-after-merge"
 
       - name: Setup Git config
         run: |

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -80,11 +80,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install clang
-        id: install-clang
-        uses: egor-tensin/setup-clang@v1
-
-          
       # macOS-specific setup
       - name: Install libusb 1.0.27 (macOS)
         if: matrix.os == 'macos'
@@ -209,9 +204,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install clang
-        uses: egor-tensin/setup-clang@v1
-  
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -100,8 +100,9 @@ jobs:
           sudo make install
           brew install llvm
           brew link llvm
-          export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-          export LIBCLANG_PATH=$(brew --prefix llvm)/lib
+          echo "LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
+
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -243,4 +244,5 @@ jobs:
         run: |
           echo "$LLVM_CONFIG_PATH"
           echo "$LIBCLANG_PATH"
+          ls -ltrh target/
           cargo nextest run ${{ matrix.flags }}

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -224,8 +224,8 @@ jobs:
       - name: Install clang on macOS
         if: contains(matrix.runner_label, 'macos')
         run: |
-          brew install llvm@20
-          brew link llvm@20
+          brew install llvm
+          brew link llvm
           echo "LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config" >> $GITHUB_ENV
           echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
 

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -203,6 +203,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-targets: false
 
       - name: Setup Git config
         run: |

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -241,10 +241,4 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           HTTP_ARCHIVE_URLS: ${{ secrets.HTTP_ARCHIVE_URLS }}
           WS_ARCHIVE_URLS: ${{ secrets.WS_ARCHIVE_URLS }}
-        run: |
-          echo "$LLVM_CONFIG_PATH"
-          echo "$LIBCLANG_PATH"
-          ls -ltrh target/
-          pwd
-          rm -rf target/
-          cargo nextest run ${{ matrix.flags }}
+        run: cargo nextest run ${{ matrix.flags }}

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -98,11 +98,14 @@ jobs:
           ./configure --prefix=/usr/local
           make
           sudo make install
+
+      - name: Install clang (macOS)
+        if: matrix.os == 'macos'
+        run: |
           brew install llvm
           brew link llvm
           echo "LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config" >> $GITHUB_ENV
           echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
-
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -217,13 +220,13 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install clang on ubuntu
+      - name: Install clang (Ubuntu)
         if: contains(matrix.runner_label, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev
   
-      - name: Install clang on macOS
+      - name: Install clang (macOS)
         if: contains(matrix.runner_label, 'macos')
         run: |
           brew install llvm

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -245,4 +245,6 @@ jobs:
           echo "$LLVM_CONFIG_PATH"
           echo "$LIBCLANG_PATH"
           ls -ltrh target/
+          pwd
+          rm -rf target/
           cargo nextest run ${{ matrix.flags }}

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -226,8 +226,8 @@ jobs:
         run: |
           brew install llvm@20
           brew link llvm@20
-          export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-          export LIBCLANG_PATH=$(brew --prefix llvm)/lib
+          echo "LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config" >> $GITHUB_ENV
+          echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -80,10 +80,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install clang
-        id: install-clang
-        if: matrix.os != 'macos'
-        uses: egor-tensin/setup-clang@v1
+      - name: Install clang on ubuntu
+        if: matrix.os == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
 
           
       # macOS-specific setup
@@ -97,6 +98,8 @@ jobs:
           ./configure --prefix=/usr/local
           make
           sudo make install
+          brew install llvm@20
+          brew link llvm@20
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -210,10 +213,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install clang
-        uses: egor-tensin/setup-clang@v1
-        if: matrix.os != 'macos'
+      - name: Install clang on ubuntu
+        if: contains(matrix.runner_label, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
   
+      - name: Install clang on macOS
+        if: contains(matrix.runner_label, 'macos')
+        run: |
+          brew install llvm@20
+          brew link llvm@20
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,13 +59,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install clang on ubuntu
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
@@ -87,13 +87,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
       - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install clang on ubuntu
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
@@ -120,13 +120,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install clang on ubuntu
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: forge fmt
         shell: bash
         run: ./.github/scripts/format.sh --check
@@ -142,6 +142,10 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
           target: wasm32-unknown-unknown
           components: rust-src
           toolchain: nightly-x86_64-unknown-linux-gnu
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
@@ -55,6 +59,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protobuf-compiler
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -79,6 +87,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
       - name: Install protobuf-compiler
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +120,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protobuf-compiler
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,8 +1220,8 @@ dependencies = [
  "serde",
  "serde_json",
  "substrate-runtime",
- "subxt 0.41.0",
- "subxt-signer 0.41.0",
+ "subxt",
+ "subxt-signer",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -7152,7 +7152,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "snapbox",
- "subxt 0.41.0",
+ "subxt",
  "tempfile",
  "tokio",
  "tracing",
@@ -7237,25 +7237,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
-dependencies = [
- "frame-metadata 21.0.0",
- "parity-scale-codec",
- "scale-decode",
- "scale-info",
- "scale-type-resolver",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "frame-decode"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e56c0e51972d7b26ff76966c4d0f2307030df9daa5ce0885149ece1ab7ca5ad"
 dependencies = [
- "frame-metadata 23.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -7311,29 +7297,6 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
- "serde",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "frame-metadata"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
@@ -7371,7 +7334,7 @@ dependencies = [
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 23.0.0",
+ "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
@@ -8049,7 +8012,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -12780,7 +12742,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "substrate-bn",
- "subxt-signer 0.43.0",
+ "subxt-signer",
 ]
 
 [[package]]
@@ -12811,8 +12773,8 @@ dependencies = [
  "sp-weights",
  "sqlx",
  "substrate-prometheus-endpoint",
- "subxt 0.43.0",
- "subxt-signer 0.43.0",
+ "subxt",
+ "subxt-signer",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -16287,16 +16249,6 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
-dependencies = [
- "byteorder",
- "derive_more 0.99.20",
-]
-
-[[package]]
-name = "ruzstd"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
@@ -18273,60 +18225,6 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
-dependencies = [
- "arrayvec 0.7.6",
- "async-lock",
- "atomic-take",
- "base64 0.22.1",
- "bip39",
- "blake2-rfc",
- "bs58",
- "chacha20",
- "crossbeam-queue",
- "derive_more 0.99.20",
- "ed25519-zebra",
- "either",
- "event-listener 5.4.1",
- "fnv",
- "futures-lite",
- "futures-util",
- "hashbrown 0.14.5",
- "hex",
- "hmac 0.12.1",
- "itertools 0.13.0",
- "libm",
- "libsecp256k1",
- "merlin",
- "nom 7.1.3",
- "num-bigint",
- "num-rational",
- "num-traits",
- "pbkdf2 0.12.2",
- "pin-project 1.1.10",
- "poly1305",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "ruzstd 0.6.0",
- "schnorrkel 0.11.5",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3",
- "siphasher 1.0.1",
- "slab",
- "smallvec",
- "soketto",
- "twox-hash 1.6.3",
- "wasmi 0.32.3",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "smoldot"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16e5723359f0048bf64bfdfba64e5732a56847d42c4fd3fe56f18280c813413"
@@ -18363,7 +18261,7 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "ruzstd 0.8.1",
+ "ruzstd",
  "schnorrkel 0.11.5",
  "serde",
  "serde_json",
@@ -18376,42 +18274,6 @@ dependencies = [
  "twox-hash 2.1.2",
  "wasmi 0.40.0",
  "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "smoldot-light"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
-dependencies = [
- "async-channel 2.5.0",
- "async-lock",
- "base64 0.22.1",
- "blake2-rfc",
- "bs58",
- "derive_more 0.99.20",
- "either",
- "event-listener 5.4.1",
- "fnv",
- "futures-channel",
- "futures-lite",
- "futures-util",
- "hashbrown 0.14.5",
- "hex",
- "itertools 0.13.0",
- "log",
- "lru 0.12.5",
- "parking_lot 0.12.4",
- "pin-project 1.1.10",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "siphasher 1.0.1",
- "slab",
- "smol",
- "smoldot 0.18.0",
  "zeroize",
 ]
 
@@ -18447,7 +18309,7 @@ dependencies = [
  "siphasher 1.0.1",
  "slab",
  "smol",
- "smoldot 0.19.4",
+ "smoldot",
  "zeroize",
 ]
 
@@ -19180,7 +19042,7 @@ name = "sp-metadata-ir"
 version = "0.6.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-metadata 23.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -20176,43 +20038,6 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
-dependencies = [
- "async-trait",
- "derive-where",
- "either",
- "frame-metadata 20.0.0",
- "futures",
- "hex",
- "jsonrpsee",
- "parity-scale-codec",
- "primitive-types 0.13.1",
- "scale-bits",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "scale-value",
- "serde",
- "serde_json",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.41.0",
- "subxt-lightclient 0.41.0",
- "subxt-macro 0.41.0",
- "subxt-metadata 0.41.0",
- "subxt-rpcs 0.41.0",
- "thiserror 2.0.12",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
- "wasm-bindgen-futures",
- "web-time",
-]
-
-[[package]]
-name = "subxt"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74791ddeaaa6de42e7cc8a715c83eb73303f513f90af701fd07eb2caad92ed84"
@@ -20220,7 +20045,7 @@ dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 23.0.0",
+ "frame-metadata",
  "futures",
  "hex",
  "jsonrpsee",
@@ -20234,11 +20059,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.43.0",
- "subxt-lightclient 0.43.0",
- "subxt-macro 0.43.0",
- "subxt-metadata 0.43.0",
- "subxt-rpcs 0.43.0",
+ "subxt-core",
+ "subxt-lightclient",
+ "subxt-macro",
+ "subxt-metadata",
+ "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -20246,23 +20071,6 @@ dependencies = [
  "url",
  "wasm-bindgen-futures",
  "web-time",
-]
-
-[[package]]
-name = "subxt-codegen"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
-dependencies = [
- "heck 0.5.0",
- "parity-scale-codec",
- "proc-macro2",
- "quote",
- "scale-info",
- "scale-typegen",
- "subxt-metadata 0.41.0",
- "syn 2.0.104",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -20277,39 +20085,9 @@ dependencies = [
  "quote",
  "scale-info",
  "scale-typegen",
- "subxt-metadata 0.43.0",
+ "subxt-metadata",
  "syn 2.0.104",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "subxt-core"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
-dependencies = [
- "base58",
- "blake2 0.10.6",
- "derive-where",
- "frame-decode 0.7.1",
- "frame-metadata 20.0.0",
- "hashbrown 0.14.5",
- "hex",
- "impl-serde",
- "keccak-hash",
- "parity-scale-codec",
- "primitive-types 0.13.1",
- "scale-bits",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "scale-value",
- "serde",
- "serde_json",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-metadata 0.41.0",
- "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]
@@ -20321,8 +20099,8 @@ dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
- "frame-decode 0.8.3",
- "frame-metadata 23.0.0",
+ "frame-decode",
+ "frame-metadata",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde",
@@ -20337,25 +20115,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-metadata 0.43.0",
+ "subxt-metadata",
  "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "subxt-lightclient"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
-dependencies = [
- "futures",
- "futures-util",
- "serde",
- "serde_json",
- "smoldot-light 0.16.2",
- "thiserror 2.0.12",
- "tokio",
- "tokio-stream",
  "tracing",
 ]
 
@@ -20369,27 +20130,11 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light 0.17.2",
+ "smoldot-light",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "subxt-macro"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
-dependencies = [
- "darling 0.20.11",
- "parity-scale-codec",
- "proc-macro-error2",
- "quote",
- "scale-typegen",
- "subxt-codegen 0.41.0",
- "subxt-utils-fetchmetadata 0.41.0",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -20403,25 +20148,10 @@ dependencies = [
  "proc-macro-error2",
  "quote",
  "scale-typegen",
- "subxt-codegen 0.43.0",
- "subxt-metadata 0.43.0",
- "subxt-utils-fetchmetadata 0.43.0",
+ "subxt-codegen",
+ "subxt-metadata",
+ "subxt-utils-fetchmetadata",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "subxt-metadata"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
-dependencies = [
- "frame-decode 0.7.1",
- "frame-metadata 20.0.0",
- "hashbrown 0.14.5",
- "parity-scale-codec",
- "scale-info",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -20430,37 +20160,13 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
 dependencies = [
- "frame-decode 0.8.3",
- "frame-metadata 23.0.0",
+ "frame-decode",
+ "frame-metadata",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "subxt-rpcs"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
-dependencies = [
- "derive-where",
- "frame-metadata 20.0.0",
- "futures",
- "hex",
- "impl-serde",
- "jsonrpsee",
- "parity-scale-codec",
- "primitive-types 0.13.1",
- "serde",
- "serde_json",
- "subxt-core 0.41.0",
- "subxt-lightclient 0.41.0",
- "thiserror 2.0.12",
- "tokio-util",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -20471,7 +20177,7 @@ checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
 dependencies = [
  "derive-where",
  "finito",
- "frame-metadata 23.0.0",
+ "frame-metadata",
  "futures",
  "hex",
  "impl-serde",
@@ -20480,41 +20186,13 @@ dependencies = [
  "primitive-types 0.13.1",
  "serde",
  "serde_json",
- "subxt-core 0.43.0",
- "subxt-lightclient 0.43.0",
+ "subxt-core",
+ "subxt-lightclient",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "subxt-signer"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
-dependencies = [
- "base64 0.22.1",
- "bip39",
- "cfg-if",
- "crypto_secretbox",
- "hex",
- "hmac 0.12.1",
- "parity-scale-codec",
- "pbkdf2 0.12.2",
- "regex",
- "schnorrkel 0.11.5",
- "scrypt 0.11.0",
- "secp256k1 0.30.0",
- "secrecy 0.10.3",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.41.0",
- "thiserror 2.0.12",
- "zeroize",
 ]
 
 [[package]]
@@ -20542,20 +20220,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.43.0",
+ "subxt-core",
  "thiserror 2.0.12",
  "zeroize",
-]
-
-[[package]]
-name = "subxt-utils-fetchmetadata"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
-dependencies = [
- "hex",
- "parity-scale-codec",
- "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,20 +14,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli 0.27.3",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.1",
+ "gimli",
 ]
 
 [[package]]
@@ -942,7 +933,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -1224,12 +1215,12 @@ dependencies = [
  "op-alloy-rpc-types",
  "parity-scale-codec",
  "parking_lot 0.12.4",
- "polkadot-sdk 2507.2.0",
+ "polkadot-sdk",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "substrate-runtime",
- "subxt",
+ "subxt 0.41.0",
  "subxt-signer 0.41.0",
  "tempfile",
  "thiserror 2.0.12",
@@ -1913,7 +1904,7 @@ dependencies = [
  "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -1929,7 +1920,7 @@ dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.12",
@@ -1982,60 +1973,29 @@ name = "asset-test-utils"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-pallet-parachain-system 0.7.0",
- "cumulus-pallet-xcmp-queue 0.7.1",
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-asset-conversion 10.0.0",
- "pallet-assets 29.1.0",
- "pallet-balances 28.0.0",
- "pallet-collator-selection 9.0.0",
- "pallet-session 28.0.0",
- "pallet-timestamp 27.0.0",
- "pallet-xcm 7.0.0",
- "pallet-xcm-bridge-hub-router 0.5.0",
- "parachains-common 7.0.0",
- "parachains-runtimes-test-utils 7.0.0",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "pallet-asset-conversion",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-session",
+ "pallet-timestamp",
+ "pallet-xcm",
+ "pallet-xcm-bridge-hub-router",
+ "parachains-common",
+ "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-parachain-info 0.7.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
- "xcm-runtime-apis 0.1.1",
-]
-
-[[package]]
-name = "asset-test-utils"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898d74874dfa06cad51722d4c7c69dae3bbb1f17d69aa3e740be7230b9b288c2"
-dependencies = [
- "cumulus-pallet-parachain-system 0.22.1",
- "cumulus-pallet-xcmp-queue 0.22.1",
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-asset-conversion 24.0.0",
- "pallet-assets 45.0.0",
- "pallet-balances 43.0.1",
- "pallet-collator-selection 23.0.0",
- "pallet-session 42.0.0",
- "pallet-timestamp 41.0.0",
- "pallet-xcm 22.0.1",
- "pallet-xcm-bridge-hub-router 0.20.0",
- "parachains-common 24.0.0",
- "parachains-runtimes-test-utils 25.0.0",
- "parity-scale-codec",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-parachain-info 0.22.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
- "xcm-runtime-apis 0.9.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-parachain-info",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -2043,53 +2003,25 @@ name = "assets-common"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "ethereum-standards 0.1.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "cumulus-primitives-core",
+ "ethereum-standards",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-asset-conversion 10.0.0",
- "pallet-assets 29.1.0",
- "pallet-revive 0.1.0",
- "pallet-revive-uapi 0.1.0",
- "pallet-xcm 7.0.0",
- "parachains-common 7.0.0",
+ "pallet-asset-conversion",
+ "pallet-assets",
+ "pallet-revive",
+ "pallet-revive-uapi",
+ "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
- "tracing",
-]
-
-[[package]]
-name = "assets-common"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b2980c3c6e01a6fa0cb3e410229f16eb52959c983c7cf1fa79a30d7dcf6ae"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "ethereum-standards 0.1.2",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "pallet-asset-conversion 24.0.0",
- "pallet-assets 45.0.0",
- "pallet-revive 0.9.0",
- "pallet-revive-uapi 0.7.0",
- "pallet-xcm 22.0.1",
- "parachains-common 24.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
 ]
 
@@ -2782,7 +2714,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -2821,11 +2753,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -2899,47 +2831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binary-merkle-tree"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "181f5380e435b8ba6d901f8b16fc8908c6f0f8bea8973113d1c8718d89bb1809"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.65.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2851,24 @@ dependencies = [
  "shlex",
  "syn 2.0.104",
  "which 4.4.2",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3235,34 +3144,16 @@ name = "bp-header-chain"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-runtime 0.7.0",
+ "bp-runtime",
  "finality-grandpa",
- "frame-support 28.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-grandpa 13.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "bp-header-chain"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8039b26d310a636b4735f223cc00af977bd3fabbd439ea16f3854e648b2e4ab"
-dependencies = [
- "bp-runtime 0.22.0",
- "finality-grandpa",
- "frame-support 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-consensus-grandpa 25.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3270,32 +3161,15 @@ name = "bp-messages"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
+ "bp-header-chain",
+ "bp-runtime",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "bp-messages"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67236312630a45aa6ca19e60cf128ec46145f6593134277d164e180db2c13d3"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -3303,34 +3177,16 @@ name = "bp-parachains"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
+ "bp-header-chain",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "bp-parachains"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0e74325a9f5ccc8263c37e8ad69468398c03fb27fa75e636b0ef5fd39275b7"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3338,34 +3194,16 @@ name = "bp-polkadot-core"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-messages 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "bp-polkadot-core"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abaabe9d796a5473cf8d44adf87642ab9a4df18112946257381561055dcc93dd"
-dependencies = [
- "bp-messages 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3373,36 +3211,17 @@ name = "bp-relayers"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-parachains 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-utility 28.0.0",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-parachains",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "bp-relayers"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e54c7ba269b41226c36403e3231a49aa363d3461ec12c5592e984da3ba2a87"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-parachains 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-utility 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3410,87 +3229,42 @@ name = "bp-runtime"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "hash-db",
  "impl-trait-for-tuples",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
  "tracing",
  "trie-db",
 ]
 
 [[package]]
-name = "bp-runtime"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d38076def82e139d397a62a0a0ea6a1d29013849a53a60bee918f5e800c4c70"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "hash-db",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
- "trie-db",
-]
-
-[[package]]
 name = "bp-test-utils"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-parachains 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-runtime 0.7.0",
+ "bp-header-chain",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-runtime",
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
- "sp-application-crypto 30.0.0",
- "sp-consensus-grandpa 13.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "bp-test-utils"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fb0592b10e593472f36c283486f16a62cbeebc7ae8ba4ab9420c5a6cd7309f"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-parachains 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-runtime 0.22.0",
- "ed25519-dalek",
- "finality-grandpa",
- "parity-scale-codec",
- "sp-application-crypto 42.0.0",
- "sp-consensus-grandpa 25.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
+ "sp-application-crypto",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
 ]
 
 [[package]]
@@ -3498,34 +3272,16 @@ name = "bp-xcm-bridge-hub"
 version = "0.2.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-messages 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "bp-xcm-bridge-hub"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690aa9ce6393794ac000a02d155b3d21ba6527a790595d6ae57c30054f182952"
-dependencies = [
- "bp-messages 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -3535,22 +3291,9 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "bp-xcm-bridge-hub-router"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ed0da6c853daa543649abd49cdfc075980a91bcaf00d9d2af0992cd870d5b5"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
+ "sp-core",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -3558,38 +3301,18 @@ name = "bridge-hub-common"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "pallet-message-queue 31.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "pallet-message-queue",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-core 0.2.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "bridge-hub-common"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc87afc72a125a959f82aa1e4410cc86b1f8f178bda72fdb9b5be6c8b58ef570"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "pallet-message-queue 45.0.0",
- "parity-scale-codec",
- "scale-info",
- "snowbridge-core 0.15.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "snowbridge-core",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -3597,84 +3320,41 @@ name = "bridge-hub-test-utils"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "asset-test-utils 7.0.0",
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-parachains 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-relayers 0.7.0",
- "bp-runtime 0.7.0",
- "bp-test-utils 0.7.0",
- "cumulus-pallet-parachain-system 0.7.0",
- "cumulus-pallet-xcmp-queue 0.7.1",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "asset-test-utils",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-relayers",
+ "bp-runtime",
+ "bp-test-utils",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcmp-queue",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-balances 28.0.0",
- "pallet-bridge-grandpa 0.7.0",
- "pallet-bridge-messages 0.7.0",
- "pallet-bridge-parachains 0.7.0",
- "pallet-bridge-relayers 0.7.0",
- "pallet-timestamp 27.0.0",
- "pallet-utility 28.0.0",
- "pallet-xcm 7.0.0",
- "pallet-xcm-bridge-hub 0.2.0",
- "parachains-common 7.0.0",
- "parachains-runtimes-test-utils 7.0.0",
+ "pallet-balances",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-bridge-parachains",
+ "pallet-bridge-relayers",
+ "pallet-timestamp",
+ "pallet-utility",
+ "pallet-xcm",
+ "pallet-xcm-bridge-hub",
+ "parachains-common",
+ "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-tracing 16.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-keyring",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
-]
-
-[[package]]
-name = "bridge-hub-test-utils"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c461ddad9beedd9af7983ac350e4568ce79888615e3b91de1220a9092aa24e41"
-dependencies = [
- "asset-test-utils 26.0.1",
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-parachains 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-relayers 0.22.0",
- "bp-runtime 0.22.0",
- "bp-test-utils 0.22.0",
- "cumulus-pallet-parachain-system 0.22.1",
- "cumulus-pallet-xcmp-queue 0.22.1",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 43.0.1",
- "pallet-bridge-grandpa 0.22.0",
- "pallet-bridge-messages 0.22.0",
- "pallet-bridge-parachains 0.22.0",
- "pallet-bridge-relayers 0.22.0",
- "pallet-timestamp 41.0.0",
- "pallet-utility 42.0.0",
- "pallet-xcm 22.0.1",
- "pallet-xcm-bridge-hub 0.18.0",
- "parachains-common 24.0.0",
- "parachains-runtimes-test-utils 25.0.0",
- "parity-scale-codec",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-keyring 43.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 18.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
 ]
 
 [[package]]
@@ -3682,61 +3362,29 @@ name = "bridge-runtime-common"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-parachains 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-relayers 0.7.0",
- "bp-runtime 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-bridge-grandpa 0.7.0",
- "pallet-bridge-messages 0.7.0",
- "pallet-bridge-parachains 0.7.0",
- "pallet-bridge-relayers 0.7.0",
- "pallet-transaction-payment 28.0.0",
- "pallet-utility 28.0.0",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-relayers",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-bridge-parachains",
+ "pallet-bridge-relayers",
+ "pallet-transaction-payment",
+ "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+ "sp-weights",
+ "staging-xcm",
  "tracing",
- "tuplex",
-]
-
-[[package]]
-name = "bridge-runtime-common"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1817b3d9c9df0b4ac9f01c599fbed889279b644d414e099fba15261beb06ba"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-parachains 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-relayers 0.22.0",
- "bp-runtime 0.22.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-bridge-grandpa 0.22.0",
- "pallet-bridge-messages 0.22.0",
- "pallet-bridge-parachains 0.22.0",
- "pallet-bridge-relayers 0.22.0",
- "pallet-transaction-payment 42.0.0",
- "pallet-utility 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
  "tuplex",
 ]
 
@@ -4002,7 +3650,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4663,15 +4311,6 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
@@ -4708,20 +4347,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1277fbfa94bc82c8ec4af2ded3e639d49ca5f7f3c7eeab2c66accd135ece4e70"
-dependencies = [
- "cranelift-entity 0.95.1",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
 dependencies = [
- "cranelift-entity 0.122.0",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -4736,40 +4366,20 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e8c31ad3b2270e9aeec38723888fe1b0ace3bea2b06b3f749ccf46661d3220"
-dependencies = [
- "bumpalo",
- "cranelift-bforest 0.95.1",
- "cranelift-codegen-meta 0.95.1",
- "cranelift-codegen-shared 0.95.1",
- "cranelift-entity 0.95.1",
- "cranelift-isle 0.95.1",
- "gimli 0.27.3",
- "hashbrown 0.13.2",
- "log",
- "regalloc2 0.6.1",
- "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-codegen"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
- "cranelift-bforest 0.122.0",
+ "cranelift-bforest",
  "cranelift-bitset",
- "cranelift-codegen-meta 0.122.0",
- "cranelift-codegen-shared 0.122.0",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
  "cranelift-control",
- "cranelift-entity 0.122.0",
- "cranelift-isle 0.122.0",
- "gimli 0.31.1",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
  "hashbrown 0.15.4",
  "log",
  "pulley-interpreter",
@@ -4777,17 +4387,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
  "wasmtime-internal-math",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ac5ac30d62b2d66f12651f6b606dbdfd9c2cfd0908de6b387560a277c5c9da"
-dependencies = [
- "cranelift-codegen-shared 0.95.1",
 ]
 
 [[package]]
@@ -4797,16 +4398,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
 dependencies = [
  "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared 0.122.0",
+ "cranelift-codegen-shared",
  "cranelift-srcgen",
  "pulley-interpreter",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd82b8b376247834b59ed9bdc0ddeb50f517452827d4a11bccf5937b213748b8"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -4825,15 +4420,6 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40099d38061b37e505e63f89bab52199037a72b931ad4868d9089ff7268660b0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
@@ -4845,33 +4431,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a25d9d0a0ae3079c463c34115ec59507b4707175454f0eee0891e83e30e82d"
-dependencies = [
- "cranelift-codegen 0.95.1",
- "log",
- "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-frontend"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
 dependencies = [
- "cranelift-codegen 0.122.0",
+ "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80de6a7d0486e4acbd5f9f87ec49912bf4c8fb6aea00087b989685460d4469ba"
 
 [[package]]
 name = "cranelift-isle"
@@ -4881,24 +4449,13 @@ checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
 
 [[package]]
 name = "cranelift-native"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6b03e0e03801c4b3fd8ce0758a94750c07a44e7944cc0ffbf0d3f2e7c79b00"
-dependencies = [
- "cranelift-codegen 0.95.1",
- "libc",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-native"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
 dependencies = [
- "cranelift-codegen 0.122.0",
+ "cranelift-codegen",
  "libc",
- "target-lexicon 0.13.3",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -4906,22 +4463,6 @@ name = "cranelift-srcgen"
 version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
-
-[[package]]
-name = "cranelift-wasm"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3220489a3d928ad91e59dd7aeaa8b3de18afb554a6211213673a71c90737ac"
-dependencies = [
- "cranelift-codegen 0.95.1",
- "cranelift-entity 0.95.1",
- "cranelift-frontend 0.95.1",
- "itertools 0.10.5",
- "log",
- "smallvec",
- "wasmparser 0.102.0",
- "wasmtime-types",
-]
 
 [[package]]
 name = "crc"
@@ -5132,34 +4673,16 @@ name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-pallet-parachain-system 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-aura 27.0.0",
- "pallet-timestamp 27.0.0",
+ "cumulus-pallet-parachain-system",
+ "frame-support",
+ "frame-system",
+ "pallet-aura",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "cumulus-pallet-aura-ext"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66684acdbeb80b82b4cf5e8a950586795102547c0e0cd5d2523f02899069c1c3"
-dependencies = [
- "cumulus-pallet-parachain-system 0.22.1",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-aura 41.0.0",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-consensus-aura 0.44.0",
- "sp-runtime 43.0.0",
+ "sp-application-crypto",
+ "sp-consensus-aura",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5167,34 +4690,16 @@ name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "cumulus-primitives-core",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "cumulus-pallet-dmp-queue"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419f1d890906d1c6fa5437d2b180d7f4c2a36dd8a2cfc6ff1cc73fb7bf427af2"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -5203,85 +4708,35 @@ version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bytes",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "cumulus-primitives-core 0.7.0",
- "cumulus-primitives-parachain-inherent 0.7.0",
- "cumulus-primitives-proof-size-hostfunction 0.2.0",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hashbrown 0.15.4",
  "impl-trait-for-tuples",
  "log",
- "pallet-message-queue 31.0.0",
+ "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-parachains",
  "scale-info",
- "sp-consensus-babe 0.32.0",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
  "trie-db",
-]
-
-[[package]]
-name = "cumulus-pallet-parachain-system"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6f97fba4804477d5c720a2ed4a30083336022157e6f5f2659236b84f0ebe57"
-dependencies = [
- "bytes",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cumulus-primitives-core 0.20.0",
- "cumulus-primitives-parachain-inherent 0.20.0",
- "cumulus-primitives-proof-size-hostfunction 0.14.0",
- "environmental",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "hashbrown 0.15.4",
- "impl-trait-for-tuples",
- "log",
- "pallet-message-queue 45.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "scale-info",
- "sp-consensus-babe 0.44.0",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
- "sp-version 41.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "trie-db",
-]
-
-[[package]]
-name = "cumulus-pallet-parachain-system-proc-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbaf3a1ce23ac8476481484fef5f4d500cbd15b4dad6380ce1d28134b0c1f7"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -5300,26 +4755,12 @@ name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-session 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
  "parity-scale-codec",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "cumulus-pallet-session-benchmarking"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa30f181ddc8421fc50e276d0be3d2312ecb0b3a71327059bef1a82eba7d2dd5"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5327,50 +4768,14 @@ name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-pallet-parachain-system 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-sudo 28.0.0",
+ "cumulus-pallet-parachain-system",
+ "frame-support",
+ "frame-system",
+ "pallet-sudo",
  "parity-scale-codec",
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "cumulus-pallet-solo-to-para"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9159c33e519d5288c4e4e592ace556a43d2f87c8374893834cfd9678f2c6653b"
-dependencies = [
- "cumulus-pallet-parachain-system 0.22.1",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-sudo 42.0.0",
- "parity-scale-codec",
- "polkadot-primitives 20.0.0",
- "scale-info",
- "sp-runtime 43.0.0",
-]
-
-[[package]]
-name = "cumulus-pallet-weight-reclaim"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e769fee4f1778fcbb3b4de3a17f94387c5615825276a472d5a95cd6091f56547"
-dependencies = [
- "cumulus-primitives-storage-weight-reclaim 13.0.0",
- "derive-where",
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-trie 41.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5378,18 +4783,18 @@ name = "cumulus-pallet-weight-reclaim"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-storage-weight-reclaim 1.0.0",
+ "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -5397,30 +4802,14 @@ name = "cumulus-pallet-xcm"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "cumulus-pallet-xcm"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac66b002202df011da7fb7184e10c8e68d21354ab690f67f1e89f709efbf17a"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -5430,81 +4819,38 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "approx",
  "bounded-collections 0.3.2",
- "bp-xcm-bridge-hub-router 0.6.0",
- "cumulus-primitives-core 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-message-queue 31.0.0",
+ "bp-xcm-bridge-hub-router",
+ "cumulus-primitives-core",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-runtime-common 7.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
 ]
 
 [[package]]
-name = "cumulus-pallet-xcmp-queue"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a69478745ec6eaf5107b47106af60635b7c87f04cb23a37b54d774abf80b848"
-dependencies = [
- "approx",
- "bounded-collections 0.3.2",
- "bp-xcm-bridge-hub-router 0.19.0",
- "cumulus-primitives-core 0.20.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-message-queue 45.0.0",
- "parity-scale-codec",
- "polkadot-runtime-common 21.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
-]
-
-[[package]]
 name = "cumulus-ping"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-pallet-xcm 0.7.0",
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "cumulus-pallet-xcm",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "cumulus-ping"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734aedb965fddd23623a4f682ebe00ebb0a23383989aa25ce77f2e4785f24a49"
-dependencies = [
- "cumulus-pallet-xcm 0.21.0",
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -5512,18 +4858,8 @@ name = "cumulus-primitives-aura"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-api 26.0.0",
- "sp-consensus-aura 0.32.0",
-]
-
-[[package]]
-name = "cumulus-primitives-aura"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4094f51bfc2154d36f2ccb982d394899c21de40f0b6876b04aea3a24bbacff"
-dependencies = [
- "sp-api 38.0.0",
- "sp-consensus-aura 0.44.0",
+ "sp-api",
+ "sp-consensus-aura",
 ]
 
 [[package]]
@@ -5532,32 +4868,14 @@ version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 7.0.0",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "scale-info",
- "sp-api 26.0.0",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
- "staging-xcm 7.0.1",
- "tracing",
-]
-
-[[package]]
-name = "cumulus-primitives-core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd2473d9bf48422b49254467ea422597a6cadc7e7db6e9670807a82c64f2f79"
-dependencies = [
- "parity-scale-codec",
- "polkadot-core-primitives 19.0.0",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-primitives 20.0.0",
- "scale-info",
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
- "sp-trie 41.0.0",
- "staging-xcm 18.0.0",
+ "sp-api",
+ "sp-runtime",
+ "sp-trie",
+ "staging-xcm",
  "tracing",
 ]
 
@@ -5567,27 +4885,12 @@ version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.7.0",
+ "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-parachain-inherent"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a77b892194c948099f4ff783c350f6b077f225f2fd0c838408ce8e78c030bc"
-dependencies = [
- "async-trait",
- "cumulus-primitives-core 0.20.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-trie 41.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-trie",
 ]
 
 [[package]]
@@ -5595,20 +4898,9 @@ name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-externalities 0.25.0",
- "sp-runtime-interface 24.0.0",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c902e7e33f9510b5354b54a68261694da6f37e70c20b3f115f7319da4644a2"
-dependencies = [
- "sp-externalities 0.30.0",
- "sp-runtime-interface 31.0.0",
- "sp-trie 41.0.0",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-trie",
 ]
 
 [[package]]
@@ -5616,34 +4908,16 @@ name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "cumulus-primitives-proof-size-hostfunction 0.2.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "cumulus-primitives-storage-weight-reclaim"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f87007f38c71a72af40dfedb22288220e1ffa54ec06c53640a27c6b5a77938"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "cumulus-primitives-proof-size-hostfunction 0.14.0",
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5651,20 +4925,9 @@ name = "cumulus-primitives-timestamp"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "sp-inherents 26.0.0",
- "sp-timestamp 26.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-timestamp"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a4e977c5b637c6de013eea00a7c40dc607e2e622e2793e94b57b128f62b3b"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "sp-inherents 38.0.0",
- "sp-timestamp 38.0.0",
+ "cumulus-primitives-core",
+ "sp-inherents",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -5672,34 +4935,16 @@ name = "cumulus-primitives-utility"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
  "log",
- "pallet-asset-conversion 10.0.0",
+ "pallet-asset-conversion",
  "parity-scale-codec",
- "polkadot-runtime-common 7.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "cumulus-primitives-utility"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5348576f0c544b07b2d47a66ef6a1d253d881b0bbdb5ba7abafcd5277824b033"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "log",
- "pallet-asset-conversion 24.0.0",
- "parity-scale-codec",
- "polkadot-runtime-common 21.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "polkadot-runtime-common",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -5707,26 +4952,12 @@ name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
+ "cumulus-primitives-core",
  "parity-scale-codec",
- "polkadot-primitives 7.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "cumulus-test-relay-sproof-builder"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f6ad919741c5bfe07442b2bb326868620de6488430847cead1fef54b093ca"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "parity-scale-codec",
- "polkadot-primitives 20.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-trie 41.0.0",
+ "polkadot-primitives",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -5986,7 +5217,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -6000,7 +5231,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs 0.7.1",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -6597,19 +5828,6 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
@@ -6711,15 +5929,6 @@ dependencies = [
 name = "ethereum-standards"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
-dependencies = [
- "alloy-core",
-]
-
-[[package]]
-name = "ethereum-standards"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5bb19a698ceb837a145395f230f1ee1c4ec751bc8038dfc616a669cfb4a01de"
 dependencies = [
  "alloy-core",
 ]
@@ -6835,12 +6044,6 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -6934,16 +6137,6 @@ checksum = "21ef72acf95ec3d7dbf61275be556299490a245f017cf084bd23b4f68cf9407c"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "file-per-thread-logger"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
-dependencies = [
- "env_logger 0.10.2",
- "log",
 ]
 
 [[package]]
@@ -7299,9 +6492,8 @@ dependencies = [
 
 [[package]]
 name = "fork-tree"
-version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6736bef9fd175fafbb97495565456651c43ccac2ae550faee709e11534e3621"
+version = "12.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -7960,7 +7152,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "snapbox",
- "subxt",
+ "subxt 0.41.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -8010,47 +7202,22 @@ name = "frame-benchmarking"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-support-procedural 23.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "sp-storage 19.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b574ee6e347515ef5009a895e537922f6139f278842897c43c68d93e1d1d00d"
-dependencies = [
- "frame-support 42.0.0",
- "frame-support-procedural 35.0.0",
- "frame-system 42.0.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-storage 22.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-storage",
  "static_assertions",
 ]
 
@@ -8059,28 +7226,13 @@ name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "frame-benchmarking-pallet-pov"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db5c01e14fe520b8a3f871b9e613ccafade9fadbce5ccd203bd9cf280ba071c"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8123,50 +7275,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-election-provider-solution-type"
-version = "16.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b525f462fa8121c3d143ad0d876660584f160ad5baa68c57bfeeb293c6b8fb"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-election-provider-solution-type 13.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-election-provider-solution-type",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "frame-election-provider-support"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86eea8dcef5ce472448e2dbef18fda47af32bdd79c8f752be0b166dc56355da7"
-dependencies = [
- "frame-election-provider-solution-type 16.1.1",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8175,35 +7297,16 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "aquamarine",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "frame-try-runtime 0.34.0",
+ "frame-support",
+ "frame-system",
+ "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "frame-executive"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b549213d0074ac66f32a3c566329dd299ef96386f12c8247ca60a8ef0485e3c"
-dependencies = [
- "aquamarine",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "frame-try-runtime 0.48.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -8249,29 +7352,12 @@ dependencies = [
  "array-bytes",
  "const-hex",
  "docify",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "frame-metadata-hash-extension"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288ac55b1c0e9ea617833934555b12064b7fd5cbea7f88fb295215584424dc6"
-dependencies = [
- "array-bytes",
- "const-hex",
- "docify",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8281,12 +7367,12 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "aquamarine",
  "array-bytes",
- "binary-merkle-tree 13.0.0",
+ "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata 23.0.0",
- "frame-support-procedural 23.0.0",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -8296,64 +7382,22 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-genesis-builder 0.8.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-metadata-ir 0.6.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-state-machine 0.35.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-tracing 16.0.0",
- "sp-trie 29.0.0",
- "sp-weights 27.0.0",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318417cb0d270d4a5bb8fff1619501ffbb5c484735e54113a9d9c381ad43c8fe"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "binary-merkle-tree 16.0.0",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 23.0.0",
- "frame-support-procedural 35.0.0",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-genesis-builder 0.19.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-metadata-ir 0.12.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "sp-state-machine 0.47.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 18.0.0",
- "sp-trie 41.0.0",
- "sp-weights 33.0.0",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-metadata-ir",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
+ "sp-weights",
  "tt-call",
 ]
 
@@ -8367,7 +7411,7 @@ dependencies = [
  "derive-syn-parse",
  "docify",
  "expander",
- "frame-support-procedural-tools 10.0.0",
+ "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
@@ -8378,45 +7422,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-support-procedural"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481996abeb9027d9a4d62d0c2cb4115c0ee6ef3120ad234fa2776b6313a4ed4"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
- "docify",
- "expander",
- "frame-support-procedural-tools 13.0.1",
- "itertools 0.11.0",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support-procedural-tools-derive 11.0.0",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a088fd6fda5f53ff0c17fc7551ce8bd0ead14ba742228443c8196296a7369b"
-dependencies = [
- "frame-support-procedural-tools-derive 12.0.0",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
@@ -8434,53 +7444,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-support-procedural-tools-derive"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "frame-system"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 28.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-version 29.0.0",
- "sp-weights 27.0.0",
-]
-
-[[package]]
-name = "frame-system"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8643078c6b60d4082dd566b25004ca74bce5241a167cde9e87a5ae939eeca471"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-version 41.0.0",
- "sp-weights 33.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-version",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8488,28 +7467,13 @@ name = "frame-system-benchmarking"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "frame-system-benchmarking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f127afb9d619ce43c0962775cc8a1d8da97364c37798986a6800bc0662414b"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8519,18 +7483,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "docify",
  "parity-scale-codec",
- "sp-api 26.0.0",
-]
-
-[[package]]
-name = "frame-system-rpc-runtime-api"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b776e081559afa5cba5ff6843d743a28a19af561bca26cafaedc98e2f11b6646"
-dependencies = [
- "docify",
- "parity-scale-codec",
- "sp-api 38.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -8538,22 +7491,10 @@ name = "frame-try-runtime"
 version = "0.34.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "frame-try-runtime"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fd88cbb88159c2f746de287c5f65447375972b72b3c627472c3d6ee487880d"
-dependencies = [
- "frame-support 42.0.0",
- "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8768,15 +7709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "gcloud-sdk"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8887,22 +7819,11 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
-dependencies = [
- "fallible-iterator 0.2.0",
- "indexmap 1.9.3",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "indexmap 2.10.0",
  "stable_deref_trait",
 ]
@@ -9172,12 +8093,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -9957,17 +8872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10018,7 +8922,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -10476,16 +9380,15 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644c70b92285f66bfc2032922a79000ea30af7bc2ab31902992a5dcb9b434f6"
+checksum = "e8beb5ce840610e5a945f0306f6e7a2d5b3e68ea3e64e9a4f081fa4ee5aa6525"
 dependencies = [
  "kvdb",
  "num_cpus",
  "parking_lot 0.12.4",
  "regex",
  "rocksdb",
- "smallvec",
 ]
 
 [[package]]
@@ -11037,14 +9940,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen 0.72.1",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "tikv-jemalloc-sys",
@@ -11177,12 +10079,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
@@ -11207,9 +10103,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14fb10e63363204b89d91e1292df83322fd9de5d7fa76c3d5c78ddc2f8f3efa9"
+checksum = "c666ef772d123a7643323ad4979c30dd825e9c68ec1aa5b387a6c9a9871c11ea"
 dependencies = [
  "async-trait",
  "bs58",
@@ -11239,7 +10135,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.27.0",
  "tokio-util",
  "tracing",
  "uint 0.10.0",
@@ -11341,15 +10237,6 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mach2"
@@ -11500,7 +10387,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "elasticlunr-rs",
- "env_logger 0.11.8",
+ "env_logger",
  "handlebars",
  "hex",
  "log",
@@ -11555,15 +10442,6 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -11995,7 +10873,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
  "pin-utils",
 ]
 
@@ -12049,6 +10927,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -12265,7 +11152,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -12318,18 +11205,6 @@ dependencies = [
  "ruint",
  "serde",
  "smallvec",
-]
-
-[[package]]
-name = "object"
-version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
-dependencies = [
- "crc32fast",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
- "memchr",
 ]
 
 [[package]]
@@ -12549,38 +11424,18 @@ name = "pallet-alliance"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-collective 28.0.0",
- "pallet-identity 29.0.0",
+ "pallet-collective",
+ "pallet-identity",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-alliance"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a3c9c1f48b8f74e3df419fc510f9d97f19faca7cc60bcd864f0c0a6ce47ff4"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-collective 42.0.0",
- "pallet-identity 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12588,36 +11443,17 @@ name = "pallet-asset-conversion"
 version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-asset-conversion"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24017dbf71a4c6fda76ac7e1072b09c3b351ded74d7536b0ccdf45832596546"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12625,36 +11461,17 @@ name = "pallet-asset-conversion-ops"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-asset-conversion 10.0.0",
+ "pallet-asset-conversion",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-asset-conversion-ops"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d895da63f44ba128e909043e64ba5dc3842af7edbb73862d9e19c6b3b702ca20"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-asset-conversion 24.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12662,30 +11479,14 @@ name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-asset-conversion 10.0.0",
- "pallet-transaction-payment 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-asset-conversion",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-asset-conversion-tx-payment"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e79609017f5524214b0292379b765304df691e7a917e6f47630289d694adb7"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-asset-conversion 24.0.0",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12693,28 +11494,13 @@ name = "pallet-asset-rate"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-asset-rate"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee558e822050d32504206c96795fa85e82957f043140f25401731cd38a2d0206"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12722,36 +11508,17 @@ name = "pallet-asset-rewards"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "pallet-asset-rewards"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614e2f00b461ed023508c53c125ea8443ed21b3964e22a0029404a275c497f8e"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -12759,32 +11526,15 @@ name = "pallet-asset-tx-payment"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-transaction-payment 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-asset-tx-payment"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445f9692687dc453decb673a970f9c63bacb673e9891b9a21759d2ef2a64c6b1"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12792,36 +11542,17 @@ name = "pallet-assets"
 version = "29.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "ethereum-standards 0.1.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "ethereum-standards",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-revive 0.1.0",
+ "pallet-revive",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-assets"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f51281fbe4f98b372272143c4f3bc7c12cac1ca72f87116b4b92e5045ac5f8"
-dependencies = [
- "ethereum-standards 0.1.2",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-revive 0.9.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12830,22 +11561,9 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "pallet-assets 29.1.0",
+ "pallet-assets",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-assets-freezer"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91add3776a06ccf49046d9f2b251e67247f1e1192485da1c2a8aaba5ea1eb20"
-dependencies = [
- "log",
- "pallet-assets 45.0.0",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -12854,30 +11572,14 @@ name = "pallet-assets-holder"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-assets 29.1.0",
+ "pallet-assets",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-assets-holder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c549038f0699df1d8370cea5e78de5e652a1bab42f06a7a07c860c5b97baf1c8"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-assets 45.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12886,18 +11588,7 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-atomic-swap"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c152ebb959d333e933a200ae1939d117b6464c3bb5046d57554b223b9845052"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -12906,32 +11597,15 @@ name = "pallet-aura"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-timestamp 27.0.0",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-aura"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbc09fc5d8d227d41913984a831e415d1a9c75fdf265c233c3b1515af49998"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-consensus-aura 0.44.0",
- "sp-runtime 43.0.0",
+ "sp-application-crypto",
+ "sp-consensus-aura",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12939,30 +11613,14 @@ name = "pallet-authority-discovery"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-session 28.0.0",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-authority-discovery 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-authority-discovery"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee3872ada8754f3705419d460022ac1b353002bcbb364478a94b96f9abfa20a"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-authority-discovery 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-application-crypto",
+ "sp-authority-discovery",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12970,26 +11628,12 @@ name = "pallet-authorship"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-authorship"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5029f76c4da58f2fd8de19fa4bd55471624c98da674d25e923b986a214fcdb0f"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12997,46 +11641,22 @@ name = "pallet-babe"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-session 28.0.0",
- "pallet-timestamp 27.0.0",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-consensus-babe 0.32.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-babe"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6bc15040c1323df7455329b412c483f07c031029fdba2627cc0b9b3ee96e8f"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-session 42.0.0",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-consensus-babe 0.44.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13046,40 +11666,18 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 28.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "pallet-bags-list"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9a6f2e7137de6fe976f89a65208f1c6659f59e835fa6765ce00ead5923e7bf"
-dependencies = [
- "aquamarine",
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-balances 43.0.1",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -13088,31 +11686,14 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e1d878d53272e0b47d4a55170ea6966b97ccc6f83107cf6173407c6407c730"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13120,38 +11701,18 @@ name = "pallet-beefy"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-session 28.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-consensus-beefy 13.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-beefy"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3491d571083f61ee812078c2b190f674276b2c5149d689d7d809b05746bb2cba"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-consensus-beefy 26.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
+ "sp-consensus-beefy",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13160,49 +11721,23 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
- "binary-merkle-tree 13.0.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "binary-merkle-tree",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-beefy 28.0.0",
- "pallet-mmr 27.0.0",
- "pallet-session 28.0.0",
+ "pallet-beefy",
+ "pallet-mmr",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-consensus-beefy 13.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
-]
-
-[[package]]
-name = "pallet-beefy-mmr"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9708f6729e816aaa837f449c03f2e165f73bdd5ce0f3a60d31dee8b5e2169b"
-dependencies = [
- "array-bytes",
- "binary-merkle-tree 16.0.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-beefy 43.0.0",
- "pallet-mmr 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-consensus-beefy 26.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
+ "sp-api",
+ "sp-consensus-beefy",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -13210,34 +11745,16 @@ name = "pallet-bounties"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-treasury 27.0.0",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-bounties"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c2aca9db384f9f99857b3ac27f21402cdc8fec0321109b757d537af6351ada"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-treasury 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13245,38 +11762,18 @@ name = "pallet-bridge-grandpa"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-runtime 0.7.0",
- "bp-test-utils 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "bp-header-chain",
+ "bp-runtime",
+ "bp-test-utils",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-consensus-grandpa 13.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-consensus-grandpa",
+ "sp-runtime",
+ "sp-std",
  "tracing",
-]
-
-[[package]]
-name = "pallet-bridge-grandpa"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6564e58c537a4143ea51dfd04b0bcb713f375d28cef9eb714c4c38882cdb156"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-runtime 0.22.0",
- "bp-test-utils 0.22.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-consensus-grandpa 25.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13284,38 +11781,18 @@ name = "pallet-bridge-messages"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-runtime 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-runtime",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
  "tracing",
-]
-
-[[package]]
-name = "pallet-bridge-messages"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390fa9406098bccea5cc0d41b9a0f27240f27bba76a26caae4818af7a5d96cf3"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-runtime 0.22.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
 ]
 
 [[package]]
@@ -13323,40 +11800,19 @@ name = "pallet-bridge-parachains"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-parachains 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-runtime 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-bridge-grandpa 0.7.0",
+ "bp-header-chain",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-runtime",
+ "sp-std",
  "tracing",
-]
-
-[[package]]
-name = "pallet-bridge-parachains"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c82dbd8ac21c95214786f5be5cbf7a39ebb25d858d479b44fbf4a53abe6979"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-parachains 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-runtime 0.22.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-bridge-grandpa 0.22.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13364,46 +11820,22 @@ name = "pallet-bridge-relayers"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-relayers 0.7.0",
- "bp-runtime 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-bridge-grandpa 0.7.0",
- "pallet-bridge-messages 0.7.0",
- "pallet-bridge-parachains 0.7.0",
- "pallet-transaction-payment 28.0.0",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-relayers",
+ "bp-runtime",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-bridge-parachains",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-runtime 31.0.1",
+ "sp-arithmetic",
+ "sp-runtime",
  "tracing",
-]
-
-[[package]]
-name = "pallet-bridge-relayers"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055a82112f01bcf234e72bc3980fd420b0cd772c3522814c59802368278b3a84"
-dependencies = [
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-relayers 0.22.0",
- "bp-runtime 0.22.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-bridge-grandpa 0.22.0",
- "pallet-bridge-messages 0.22.0",
- "pallet-bridge-parachains 0.22.0",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-runtime 43.0.0",
 ]
 
 [[package]]
@@ -13412,35 +11844,16 @@ version = "0.6.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bitvec",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-broker"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd709bff4e93f41c77e646e320263b0a61fefbd487368b043982f6813652a1c"
-dependencies = [
- "bitvec",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13448,36 +11861,17 @@ name = "pallet-child-bounties"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-bounties 27.0.0",
- "pallet-treasury 27.0.0",
+ "pallet-bounties",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-child-bounties"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789334ed868cf3b16f26daec3f36d2c5c56ca232a30b3270e5f23a20420e16d"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-bounties 41.0.0",
- "pallet-treasury 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13485,38 +11879,18 @@ name = "pallet-collator-selection"
 version = "9.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-session 28.0.0",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-collator-selection"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb164b63124a40ea3819b28b073a16e28b835649c5e6a7a28eb4ae7c75a14f2"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13525,33 +11899,15 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-collective"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c399d03d365241e2fd0200a76c369f32b0b58460ecdf6bde234ceb0b1ce40710"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13559,28 +11915,13 @@ name = "pallet-collective-content"
 version = "0.6.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-collective-content"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be98dabcbbbf25240890627350b3259108e3313ba43a6b577827104349bfb4a"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13589,59 +11930,28 @@ version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "environmental",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 28.0.0",
- "pallet-contracts-proc-macro 18.0.0",
- "pallet-contracts-uapi 5.0.0",
+ "pallet-balances",
+ "pallet-contracts-proc-macro",
+ "pallet-contracts-uapi",
  "parity-scale-codec",
  "paste",
  "rand 0.8.5",
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
  "wasm-instrument",
- "wasmi",
-]
-
-[[package]]
-name = "pallet-contracts"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74de71e173ce98c0e7f683a463e3b0cf7eb3c7a4845d7546532f67ebde57919b"
-dependencies = [
- "environmental",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 43.0.1",
- "pallet-contracts-proc-macro 23.0.3",
- "pallet-contracts-uapi 14.0.0",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "smallvec",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "wasm-instrument",
- "wasmi",
+ "wasmi 0.32.3",
 ]
 
 [[package]]
@@ -13649,79 +11959,36 @@ name = "pallet-contracts-mock-network"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-assets 29.1.0",
- "pallet-balances 28.0.0",
- "pallet-contracts 27.0.0",
- "pallet-contracts-uapi 5.0.0",
- "pallet-message-queue 31.0.0",
- "pallet-timestamp 27.0.0",
- "pallet-xcm 7.0.0",
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-contracts",
+ "pallet-contracts-uapi",
+ "pallet-message-queue",
+ "pallet-timestamp",
+ "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "scale-info",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
- "xcm-simulator 7.0.0",
-]
-
-[[package]]
-name = "pallet-contracts-mock-network"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5864ce9fd70665745e3b20bd0f8fb433ef62e7df5f6c6ca10cb2c993122e0faf"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-assets 45.0.0",
- "pallet-balances 43.0.1",
- "pallet-contracts 42.0.0",
- "pallet-contracts-uapi 14.0.0",
- "pallet-message-queue 45.0.0",
- "pallet-timestamp 41.0.0",
- "pallet-xcm 22.0.1",
- "parity-scale-codec",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "scale-info",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
- "xcm-simulator 22.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-tracing",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "xcm-simulator",
 ]
 
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "pallet-contracts-proc-macro"
-version = "23.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35aaa3d7f1dba4ea7b74d7015e6068b753d1f7f63b39a4ce6377de1bc51b476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13740,48 +12007,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-contracts-uapi"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1175375608ec4900f1172d304f7c7ac1f7e3710be17f365121cf94028db1630"
-dependencies = [
- "bitflags 1.3.2",
- "parity-scale-codec",
- "paste",
- "scale-info",
-]
-
-[[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-conviction-voting"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2329c0beedb0a5e7f97f94cc732f032ceec029189928ff1a0693c521df1b923"
-dependencies = [
- "assert_matches",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13789,36 +12027,17 @@ name = "pallet-core-fellowship"
 version = "12.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-ranked-collective 28.0.0",
+ "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-core-fellowship"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b427dcb2c0fe433e5c0c100a883f9579ada224f561a4cb09ce56a6c71c36c37"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-ranked-collective 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13826,30 +12045,14 @@ name = "pallet-delegated-staking"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-delegated-staking"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c3de5241c0d01fbfa005e5347f97c3091b2315b0c72f30651fa4ca2c9ba8c3"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13857,34 +12060,16 @@ name = "pallet-democracy"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-democracy"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583deb32f0ba44e8614040ad7dff6bda48de94bf567469ffc94229034a4d2a25"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13892,19 +12077,19 @@ name = "pallet-derivatives"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -13912,49 +12097,14 @@ name = "pallet-dev-mode"
 version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 28.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-dev-mode"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1362c56e82568b092deddd392c1b1294af262bb258e11c722ed9b868b0992a3"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-balances 43.0.1",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
-]
-
-[[package]]
-name = "pallet-dummy-dim"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f18ad6c2ccf8eb2520a5ed859601c999b71fd722dcc3748fc6866d5b82a25cc"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13962,39 +12112,17 @@ name = "pallet-dummy-dim"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-election-provider-multi-block"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b09ec7b126337ae8304dc2d9b96a2f9fa080a3dbe2d6ccfad84f6ef7bd40b7d"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14002,20 +12130,20 @@ name = "pallet-election-provider-multi-block"
 version = "0.9.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -14023,41 +12151,19 @@ name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "pallet-election-provider-multi-phase"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6646255b20771fe899346ff5182046c8373705c4b6650c73aeea31c8f8d7e62"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
  "strum 0.26.3",
 ]
 
@@ -14066,26 +12172,12 @@ name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-system",
  "parity-scale-codec",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-election-provider-support-benchmarking"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3baf08468977f6d7f6582d93d7bd2de98514bdaef64633cbf21c59311851030"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-npos-elections",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14093,36 +12185,17 @@ name = "pallet-elections-phragmen"
 version = "29.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-elections-phragmen"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1eafe673650e905a1cf252a13c4531b26aa3dc3fccd31a0496270bffcd2a2f"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14131,35 +12204,16 @@ version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-fast-unstake"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1034960eb3567664454f985b0fa06e2446abf5cc8e0c19ee45dfd077f6d8227"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14168,35 +12222,16 @@ version = "14.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "blake2 0.10.6",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-glutton"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8267b475202d5a2adaf370e292f44d982fc4c4cdcbd0b9b15ec98a7479a3c0"
-dependencies = [
- "blake2 0.10.6",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14204,44 +12239,21 @@ name = "pallet-grandpa"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-session 28.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-consensus-grandpa 13.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-grandpa"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9713db987b64e10d861807c4d699a5ffbf5f154bd4ddbd20c1681a9759fc9ef5"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-consensus-grandpa 25.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
+ "sp-application-crypto",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14250,31 +12262,14 @@ version = "29.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-identity"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568deb043dcbb4a209844e73d9b00c569421d592305fc4c1ee47e807039db1a2"
-dependencies = [
- "enumflags2",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14282,38 +12277,18 @@ name = "pallet-im-online"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
+ "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-im-online"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4677e482b668e906d9010285fd39352442b27f3dfe31aa4db177c81a09f41f"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14321,30 +12296,14 @@ name = "pallet-indices"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-indices"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e549533be28c2bd98cddb23a091fa32fc089ed17f956bb4f7f54036fbdad9a14"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14353,19 +12312,7 @@ version = "16.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "safe-mix",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-insecure-randomness-collective-flip"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f81949b327165ea1eda973c49bddab1c9f42fa1d1192c3dfb09665127724e0"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "safe-mix",
  "scale-info",
 ]
@@ -14375,26 +12322,12 @@ name = "pallet-lottery"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-lottery"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607114653d91743a153ffbbe571b48c4058ec3ebb2d12bdd9bffbb0d230da408"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14402,32 +12335,15 @@ name = "pallet-membership"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-membership"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd968f0ed6b2161ca213788c470855d5038109ee9924e03122a418f69aeeed05"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14436,37 +12352,17 @@ version = "31.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "environmental",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
-]
-
-[[package]]
-name = "pallet-message-queue"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9219060ceaeca85118ea8daed9298cc9e969ad0c7f5430060c2f48187261cccc"
-dependencies = [
- "environmental",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -14475,35 +12371,16 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "pallet-meta-tx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7126542a2b39616f05cfc0f583475f83c0c99f0142095e7051a86f9e230c0e76"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -14512,37 +12389,17 @@ version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-migrations"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6416aa982bb9c7dd48497a17c7e8de125318fee70c062c9e2aeec11d38f065"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14552,26 +12409,11 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
+ "polkadot-sdk-frame",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0",
- "sp-mixnet 0.4.0",
-]
-
-[[package]]
-name = "pallet-mixnet"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb15158a08981acb365f1074462355ff58f66b63c11fe6a84bc0b8e86588a88"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
- "scale-info",
- "serde",
- "sp-application-crypto 42.0.0",
- "sp-mixnet 0.16.0",
+ "sp-application-crypto",
+ "sp-mixnet",
 ]
 
 [[package]]
@@ -14581,22 +12423,9 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-mmr-primitives 26.0.0",
-]
-
-[[package]]
-name = "pallet-mmr"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27ea738b0d713846246f53718a189838ab83565ad42b3cc6e8e41c622cb0438"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
- "scale-info",
- "sp-mmr-primitives 38.0.0",
+ "sp-mmr-primitives",
 ]
 
 [[package]]
@@ -14606,19 +12435,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-multisig"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91eef837a15521edb2ef39e5428f4e0a888fb1d05ff40c1c3d1b7f06dd9a9c1a"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -14628,24 +12445,10 @@ version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "pallet-assets 29.1.0",
- "pallet-nfts 22.0.0",
+ "pallet-assets",
+ "pallet-nfts",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-nft-fractionalization"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5779d2ea9fefa8302626a2952590fc3b701312851681251e76b2f0984fcd6f2e"
-dependencies = [
- "log",
- "pallet-assets 45.0.0",
- "pallet-nfts 36.0.0",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -14655,33 +12458,15 @@ version = "22.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-nfts"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ecf5a45104e39e912493a9d899a22a8a3bfe6a34d7efe49b8d883305a4ee17"
-dependencies = [
- "enumflags2",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14690,17 +12475,7 @@ version = "14.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "sp-api 26.0.0",
-]
-
-[[package]]
-name = "pallet-nfts-runtime-api"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab34fa16e4d8132f0bdbfbf30cc4db79637ab05e26c874dc654ad05779c44f"
-dependencies = [
- "parity-scale-codec",
- "sp-api 38.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -14709,18 +12484,7 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-nis"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47d7c5a708caf1e963dc0357fc02bbb6de2e3c0d9cc6181b0b50f119638056f"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -14731,19 +12495,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "log",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-node-authorization"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3a157f0f5a42677f8af7cb2444745d1d1b744c5bfc8f67d1628f14315d5f14"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -14752,36 +12504,17 @@ name = "pallet-nomination-pools"
 version = "25.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 28.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "pallet-nomination-pools"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e433439ad3872f5cb9e1cca96181c151dab250330146f7422695d8c4efd5c3c5"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-balances 43.0.1",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "sp-tracing 18.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -14789,40 +12522,19 @@ name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-bags-list 27.0.0",
- "pallet-delegated-staking 1.0.0",
- "pallet-nomination-pools 25.0.0",
- "pallet-staking 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-bags-list",
+ "pallet-delegated-staking",
+ "pallet-nomination-pools",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-nomination-pools-benchmarking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d363c3592c52b9b3670bd5d27686934709d1d5e42d7f5b0d73295c739c9055c1"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-bags-list 41.0.0",
- "pallet-delegated-staking 9.0.0",
- "pallet-nomination-pools 40.0.0",
- "pallet-staking 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-staking 40.0.0",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14830,20 +12542,9 @@ name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "pallet-nomination-pools 25.0.0",
+ "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 26.0.0",
-]
-
-[[package]]
-name = "pallet-nomination-pools-runtime-api"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db461f3a0a8aa1f5e9d0f3bfda0813114e82a36572f0276646005b1fcb3b3c17"
-dependencies = [
- "pallet-nomination-pools 40.0.0",
- "parity-scale-codec",
- "sp-api 38.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -14851,30 +12552,14 @@ name = "pallet-offences"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-offences"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da1273ffa5883dea90e8cd8c6bdcb508f21699c75311867870d32b160b218c9"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14882,65 +12567,22 @@ name = "pallet-offences-benchmarking"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-babe 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-grandpa 28.0.0",
- "pallet-im-online 27.0.0",
- "pallet-offences 27.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-grandpa",
+ "pallet-im-online",
+ "pallet-offences",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-offences-benchmarking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5b0575133533330b4331e2bafc263af1863dd1eb022371ab1b0258a1b3e14e"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-babe 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-grandpa 42.0.0",
- "pallet-im-online 41.0.0",
- "pallet-offences 41.0.0",
- "pallet-session 42.0.0",
- "pallet-staking 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
-]
-
-[[package]]
-name = "pallet-origin-restriction"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe194c26b7a2d69bfb60e00e09cce13aaa4939aa828715ba70440be8aace30c"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -14948,17 +12590,17 @@ name = "pallet-origin-restriction"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-transaction-payment 28.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14968,22 +12610,9 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "docify",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-metadata-ir 0.6.0",
-]
-
-[[package]]
-name = "pallet-paged-list"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481070b8274e43f2b35ec5041d9e4d72976d96b6b0768c4755c8fe8d335f0179"
-dependencies = [
- "docify",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
- "scale-info",
- "sp-metadata-ir 0.12.0",
+ "sp-metadata-ir",
 ]
 
 [[package]]
@@ -14992,52 +12621,15 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-parameters"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650d5a9db708dd87016d6c4d576314ebdb08c1b7c5225237a1157801e4d4924"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
-]
-
-[[package]]
-name = "pallet-people"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d563f9b3bca68db2205d82e830abf7f74c5d2f21219cc72fc76b35cbb1ccbddc"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "verifiable",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15045,16 +12637,16 @@ name = "pallet-people"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "verifiable",
 ]
 
@@ -15063,32 +12655,15 @@ name = "pallet-preimage"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-preimage"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3832a0304a2ed61c80fadca264e02ea47a0be1d5af787424c28d9703a2bc68"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15097,18 +12672,7 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-proxy"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23a8e2820734e33378a14c483465e347924893e59076a9292eacbc0250658b2"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -15117,36 +12681,17 @@ name = "pallet-ranked-collective"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-ranked-collective"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848934ea52fed988abca765146a24db3b21641c7fa467f9ad328f10655b511c2"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15155,18 +12700,7 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-recovery"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f2db46ae18bed0b88971cd9751e733e169dfa6ade87a9f639b5278985f5a51"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -15175,34 +12709,16 @@ name = "pallet-referenda"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-referenda"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fa547365fac83de533669b2e3bb96484e3b207c27da9c204db5d87c937d6a8"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic 28.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15210,32 +12726,15 @@ name = "pallet-remark"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-remark"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6894af0b0c360d04698c49a3e167a2e9aee28193ee06c30dcc534b51057d8c7"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15246,11 +12745,11 @@ dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
  "environmental",
- "ethereum-standards 0.1.0",
+ "ethereum-standards",
  "ethereum-types",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "humantime-serde",
  "impl-trait-for-tuples",
@@ -15258,10 +12757,10 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "pallet-revive-fixtures 0.1.0",
- "pallet-revive-proc-macro 0.1.0",
- "pallet-revive-uapi 0.1.0",
- "pallet-transaction-payment 28.0.0",
+ "pallet-revive-fixtures",
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
  "polkavm 0.27.0",
@@ -15272,69 +12771,22 @@ dependencies = [
  "rlp 0.6.1",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-consensus-babe 0.32.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "substrate-bn",
  "subxt-signer 0.43.0",
 ]
 
 [[package]]
-name = "pallet-revive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb75207e6a983d292de1fa281c8c09e67b995928dbbdf44ced5bd2b75ad19fae"
-dependencies = [
- "alloy-core",
- "derive_more 0.99.20",
- "environmental",
- "ethereum-standards 0.1.2",
- "ethereum-types",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "hex-literal",
- "humantime-serde",
- "impl-trait-for-tuples",
- "log",
- "num-bigint",
- "num-integer",
- "num-traits",
- "pallet-revive-fixtures 0.6.0",
- "pallet-revive-proc-macro 0.4.0",
- "pallet-revive-uapi 0.7.0",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "paste",
- "polkavm 0.27.0",
- "polkavm-common 0.27.0",
- "rand 0.8.5",
- "ripemd",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-consensus-aura 0.44.0",
- "sp-consensus-babe 0.44.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "substrate-bn",
- "subxt-signer 0.41.0",
-]
-
-[[package]]
 name = "pallet-revive-eth-rpc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d97739b89230f8982b1a99ff24c4c9a81b24d4b0c89789eb4b69fd05bb2bdae"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "anyhow",
  "clap",
@@ -15343,7 +12795,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "log",
- "pallet-revive 0.9.0",
+ "pallet-revive",
  "parity-scale-codec",
  "rlp 0.6.1",
  "sc-cli",
@@ -15351,16 +12803,16 @@ dependencies = [
  "sc-rpc-api",
  "sc-service",
  "serde_json",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-runtime",
+ "sp-weights",
  "sqlx",
- "substrate-prometheus-endpoint 0.17.7",
- "subxt",
- "subxt-signer 0.41.0",
+ "substrate-prometheus-endpoint",
+ "subxt 0.43.0",
+ "subxt-signer 0.43.0",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -15374,26 +12826,11 @@ dependencies = [
  "anyhow",
  "cargo_metadata 0.15.4",
  "hex",
- "pallet-revive-uapi 0.1.0",
+ "pallet-revive-uapi",
  "polkavm-linker 0.27.0",
  "serde_json",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "pallet-revive-fixtures"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140b59f0454fd411fce85c0ac0347a5c4efa73b451a342109ac04ec00d870112"
-dependencies = [
- "anyhow",
- "cargo_metadata 0.15.4",
- "pallet-revive-uapi 0.7.0",
- "polkavm-linker 0.27.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
+ "sp-core",
+ "sp-io",
  "toml 0.8.23",
 ]
 
@@ -15401,17 +12838,6 @@ dependencies = [
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "pallet-revive-proc-macro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb9c42c125790dd4bb0132312bb1a9d3a890b4720c7696d636194311f948e36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15427,20 +12853,7 @@ dependencies = [
  "bitflags 1.3.2",
  "const-crypto",
  "hex-literal",
- "pallet-revive-proc-macro 0.1.0",
- "parity-scale-codec",
- "polkavm-derive 0.27.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-revive-uapi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e340813d94f380bc531d4cd5f28685065a14dbbff87ab23507f72c7d2792b82c"
-dependencies = [
- "bitflags 1.3.2",
- "pallet-revive-proc-macro 0.4.0",
+ "pallet-revive-proc-macro",
  "parity-scale-codec",
  "polkavm-derive 0.27.0",
  "scale-info",
@@ -15451,32 +12864,15 @@ name = "pallet-root-offences"
 version = "25.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-root-offences"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b20e720c8b62f1c0089f4e2212ddb255071f0442ad56891a0271bdb49ed54fe"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-session 42.0.0",
- "pallet-staking 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -15484,26 +12880,12 @@ name = "pallet-root-testing"
 version = "4.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-root-testing"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4013180d44df890d4fff97241937d1a90516a623b39b33c0803ea42fc370dc5d"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15512,26 +12894,11 @@ version = "9.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "pallet-balances 28.0.0",
- "pallet-proxy 28.0.0",
- "pallet-utility 28.0.0",
+ "pallet-balances",
+ "pallet-proxy",
+ "pallet-utility",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-safe-mode"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36dc502bd0ceaa1333718c21a2b43aa1cce78cdd5d458e2713fd6871e37aecf"
-dependencies = [
- "docify",
- "pallet-balances 43.0.1",
- "pallet-proxy 42.0.0",
- "pallet-utility 42.0.0",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -15541,22 +12908,9 @@ version = "13.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "pallet-ranked-collective 28.0.0",
+ "pallet-ranked-collective",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-salary"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a35e5c058217551926b1c5ae7e7a7dcb71f3e53e793049a9dfb500edd255fd6"
-dependencies = [
- "log",
- "pallet-ranked-collective 42.0.0",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -15566,33 +12920,15 @@ version = "29.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
-]
-
-[[package]]
-name = "pallet-scheduler"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ea0b46b299938bf6e0ff31f5b7f102f169e443d0ede2104f946a9a1ef45df3"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -15600,26 +12936,12 @@ name = "pallet-scored-pool"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-scored-pool"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ecb4084bb9ffd442165930cfdeeb4560671b062221ef90272e1fe3ec6f367a"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15627,44 +12949,21 @@ name = "pallet-session"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 28.0.0",
- "pallet-timestamp 27.0.0",
+ "pallet-balances",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "pallet-session"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8784e59ba6e098211819bcc742e263912cbc0715d0dfb0030c840617ff94f1"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 43.0.1",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
- "sp-state-machine 0.47.0",
- "sp-trie 41.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -15672,32 +12971,15 @@ name = "pallet-session-benchmarking"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
-]
-
-[[package]]
-name = "pallet-session-benchmarking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e784a70984824a0bc2476ca9d3700f539df8a64ca055a6b826c6643ef6ecb70"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-session 42.0.0",
- "pallet-staking 42.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
+ "sp-runtime",
+ "sp-session",
 ]
 
 [[package]]
@@ -15705,24 +12987,11 @@ name = "pallet-skip-feeless-payment"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-skip-feeless-payment"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ef20550ab307c0e04152b312246cd86ba3bc320685cce8093872e1dc4be71c"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15730,34 +12999,16 @@ name = "pallet-society"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-society"
-version = "42.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4e6fff38693c66edec548c0fc9f6784c837795b204ed5bfd1a2c660fb61432"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15765,42 +13016,20 @@ name = "pallet-staking"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-session 28.0.0",
+ "pallet-authorship",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-staking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b544e05fb3dc7e794acf27913f066cafe0a9df72a1dfc59f687af3e890afe48"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-session 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-application-crypto 42.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -15808,47 +13037,23 @@ name = "pallet-staking-async"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-staking-async-rc-client 0.1.0",
+ "pallet-staking-async-rc-client",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-staking-async"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08e204511964e2fdf7224a3bab431ec071b3ee402b315fd5ca85011e0181a52"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-staking-async-rc-client 0.3.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -15856,41 +13061,19 @@ name = "pallet-staking-async-ah-client"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-authorship 28.0.0",
- "pallet-session 28.0.0",
- "pallet-staking-async-rc-client 0.1.0",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-staking-async-rc-client",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-staking-async-ah-client"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a6bb5a297c0b60c8b1ceb966a3455c9ce3beb6f8feaa4e9ed95926f27b9066"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-authorship 42.0.0",
- "pallet-session 42.0.0",
- "pallet-staking-async-rc-client 0.3.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -15898,44 +13081,16 @@ name = "pallet-staking-async-rc-client"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "staging-xcm 7.0.1",
-]
-
-[[package]]
-name = "pallet-staking-async-rc-client"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b9c00bbdfa226a820a5a25fa2b938926b0b9d5186cb634a7e8c5c0967e107b"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "staging-xcm 18.0.0",
-]
-
-[[package]]
-name = "pallet-staking-async-reward-fn"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb43b6b785461e309c5ce3dde29db313b9f0ba0f78b56b2706392e4eba9a956"
-dependencies = [
- "log",
- "sp-arithmetic 28.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -15944,18 +13099,7 @@ version = "19.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "sp-arithmetic 23.0.0",
-]
-
-[[package]]
-name = "pallet-staking-async-runtime-api"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e127f18d7d45e03abd4669cbde75a92420cc2e96c6fe7eeb93832e0ded41574"
-dependencies = [
- "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-staking 40.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -15964,8 +13108,8 @@ version = "14.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "sp-api 26.0.0",
- "sp-staking 26.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -15974,17 +13118,7 @@ version = "19.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "sp-arithmetic 23.0.0",
-]
-
-[[package]]
-name = "pallet-staking-reward-fn"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dddc795e22484cc18a6c25018d32fb4ad518491d9989edcd9cdd3090638512"
-dependencies = [
- "log",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -15993,19 +13127,8 @@ version = "14.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "sp-api 26.0.0",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "pallet-staking-runtime-api"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432d14fd9aefbafd379728cf73b2837cb44001afb101b5521183dcb2d4730f8f"
-dependencies = [
- "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-staking 40.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -16013,32 +13136,15 @@ name = "pallet-state-trie-migration"
 version = "29.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-state-trie-migration"
-version = "47.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c2ae186d2cfce9cb8c06fe40921d3058ed81971839e66086aafbbf1aaf02d"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16046,34 +13152,16 @@ name = "pallet-statement"
 version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-statement-store 10.0.0",
-]
-
-[[package]]
-name = "pallet-statement"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56de2ebd44756134f04182d9647843a117f7a9a339b389947e8c8bb0309e1037"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-statement-store 22.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-statement-store",
 ]
 
 [[package]]
@@ -16082,29 +13170,13 @@ version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-sudo"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0660acf8cbfa0f50ba67719c0da751fb759dad06f6bbdfc50a5155306ebdbf4"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16113,35 +13185,16 @@ version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "sp-storage 19.0.0",
- "sp-timestamp 26.0.0",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21992790039a56ff9af246896d24d6e209c7db8ab9ebd45674aff12cdd4d0074"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-storage 22.0.0",
- "sp-timestamp 38.0.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-storage",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -16149,36 +13202,17 @@ name = "pallet-tips"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-treasury 27.0.0",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-tips"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318a3bd4d5dcd4cb5b4ed4927d1c62300082080547bbebc7fac20f87e0e65d36"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-treasury 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16186,30 +13220,14 @@ name = "pallet-transaction-payment"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0ec07d135d2b3dfe0dcb2de38dd84e9b1ef8d1a8e87ca8172931efdf892ff3"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16217,24 +13235,11 @@ name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "pallet-transaction-payment 28.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 26.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
-]
-
-[[package]]
-name = "pallet-transaction-payment-rpc-runtime-api"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4278dbe286b8a7772308873e0af89602af4949c79fa2f482c56e0302629f8050"
-dependencies = [
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-api",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -16242,38 +13247,18 @@ name = "pallet-transaction-storage"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 28.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-transaction-storage-proof 26.0.0",
-]
-
-[[package]]
-name = "pallet-transaction-storage"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfaf00032db6dac2727a91e8c58d63af0cb5100b74fe6b3e9a494cffa5f5979"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-balances 43.0.1",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-transaction-storage-proof 38.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-transaction-storage-proof",
 ]
 
 [[package]]
@@ -16282,37 +13267,17 @@ version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 28.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-treasury"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d7e56a24b6970c059146e56c891d40e16142d0df37f990065e8d154506ecb"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 43.0.1",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16322,19 +13287,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "docify",
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-tx-pause"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f0f0defc80d260f06b37fa024b9bf28934869c7ea142d6da1cd580424a3f5"
-dependencies = [
- "docify",
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -16343,28 +13296,13 @@ name = "pallet-uniques"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-uniques"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b2a66c19327f8f96d152dcf3cdd31a2edc6f0a58fc031d012faaeb085acf07"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16372,46 +13310,14 @@ name = "pallet-utility"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-utility"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa33b0d92d123c8d9e6fc53713d1140e83bcf85a641ebb72dbb54805e498f99"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
-]
-
-[[package]]
-name = "pallet-verify-signature"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee262bac222ec53e20dcc12d45103d99e38828b6400726ab2639027830044b4"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16419,14 +13325,14 @@ name = "pallet-verify-signature"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -16434,28 +13340,13 @@ name = "pallet-vesting"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-vesting"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8839cf6dcd749407b338531175c4fd81033fc1853fb6ebedcb5289d3dd74ad0a"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16464,18 +13355,7 @@ version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk-frame 0.1.0",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-whitelist"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abb438ee3dc56f847a1b7624c3b4ba36fc2a426986d2236fc923f2a37b680c9"
-dependencies = [
- "parity-scale-codec",
- "polkadot-sdk-frame 0.11.0",
+ "polkadot-sdk-frame",
  "scale-info",
 ]
 
@@ -16485,50 +13365,23 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bounded-collections 0.3.2",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
- "pallet-balances 28.0.0",
- "pallet-revive 0.1.0",
+ "pallet-balances",
+ "pallet-revive",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
- "xcm-runtime-apis 0.1.1",
-]
-
-[[package]]
-name = "pallet-xcm"
-version = "22.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84831f49e34014a04f5ff97872c8d3409788981ee5d49b79dffbe80f7d22c98e"
-dependencies = [
- "bounded-collections 0.3.2",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "hex-literal",
- "pallet-balances 43.0.1",
- "pallet-revive 0.9.0",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
- "tracing",
- "xcm-runtime-apis 0.9.0",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -16536,34 +13389,16 @@ name = "pallet-xcm-benchmarks"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "pallet-xcm-benchmarks"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651ef742e6f07ae96c5e9777160840624f6514468bb3343936806222af457c8d"
-dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -16571,44 +13406,21 @@ name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-messages 0.7.0",
- "bp-runtime 0.7.0",
- "bp-xcm-bridge-hub 0.2.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-bridge-messages 0.7.0",
+ "bp-messages",
+ "bp-runtime",
+ "bp-xcm-bridge-hub",
+ "frame-support",
+ "frame-system",
+ "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "tracing",
-]
-
-[[package]]
-name = "pallet-xcm-bridge-hub"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baac6e68c02cf6e7aa8934c77c85f67a0b785559033c4798f9bfc252815cdfb5"
-dependencies = [
- "bp-messages 0.22.0",
- "bp-runtime 0.22.0",
- "bp-xcm-bridge-hub 0.8.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-bridge-messages 0.22.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
 ]
 
 [[package]]
@@ -16616,40 +13428,19 @@ name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-xcm-bridge-hub-router 0.6.0",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "bp-xcm-bridge-hub-router",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
  "tracing",
-]
-
-[[package]]
-name = "pallet-xcm-bridge-hub-router"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da52a3f06fa00aecb403daf477b7dbb174c739e75e6c0566d0c07ea642354510"
-dependencies = [
- "bp-xcm-bridge-hub-router 0.19.0",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "parity-scale-codec",
- "polkadot-runtime-parachains 21.0.1",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
 ]
 
 [[package]]
@@ -16657,62 +13448,30 @@ name = "parachains-common"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "cumulus-primitives-utility 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-asset-tx-payment 28.0.0",
- "pallet-assets 29.1.0",
- "pallet-authorship 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-collator-selection 9.0.0",
- "pallet-message-queue 31.0.0",
- "pallet-treasury 27.0.0",
- "pallet-xcm 7.0.0",
+ "cumulus-primitives-core",
+ "cumulus-primitives-utility",
+ "frame-support",
+ "frame-system",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-message-queue",
+ "pallet-treasury",
+ "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-common 7.0.0",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "scale-info",
- "sp-consensus-aura 0.32.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-parachain-info 0.7.0",
- "staging-xcm 7.0.1",
- "staging-xcm-executor 7.0.0",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-parachain-info",
+ "staging-xcm",
+ "staging-xcm-executor",
  "tracing",
-]
-
-[[package]]
-name = "parachains-common"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2052cb923c8997860ca72f6f2064d66f6ed2bb9f3df8966498a1a2a543e5833"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "cumulus-primitives-utility 0.22.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "log",
- "pallet-asset-tx-payment 42.0.0",
- "pallet-assets 45.0.0",
- "pallet-authorship 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-collator-selection 23.0.0",
- "pallet-message-queue 45.0.0",
- "pallet-treasury 41.0.0",
- "pallet-xcm 22.0.1",
- "parity-scale-codec",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-common 21.0.0",
- "scale-info",
- "sp-consensus-aura 0.44.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-parachain-info 0.22.0",
- "staging-xcm 18.0.0",
- "staging-xcm-executor 21.0.0",
 ]
 
 [[package]]
@@ -16720,62 +13479,30 @@ name = "parachains-runtimes-test-utils"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-pallet-parachain-system 0.7.0",
- "cumulus-pallet-xcmp-queue 0.7.1",
- "cumulus-primitives-core 0.7.0",
- "cumulus-primitives-parachain-inherent 0.7.0",
- "cumulus-test-relay-sproof-builder 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-collator-selection 9.0.0",
- "pallet-session 28.0.0",
- "pallet-timestamp 27.0.0",
- "pallet-xcm 7.0.0",
- "parachains-common 7.0.0",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-test-relay-sproof-builder",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-session",
+ "pallet-timestamp",
+ "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
- "staging-parachain-info 0.7.0",
- "staging-xcm 7.0.1",
- "staging-xcm-executor 7.0.0",
- "xcm-runtime-apis 0.1.1",
-]
-
-[[package]]
-name = "parachains-runtimes-test-utils"
-version = "25.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad95f5a484bf548bcab6f773506bcb56ba3782da6250b72c1a4eb1044b9c726"
-dependencies = [
- "cumulus-pallet-parachain-system 0.22.1",
- "cumulus-pallet-xcmp-queue 0.22.1",
- "cumulus-primitives-core 0.20.0",
- "cumulus-primitives-parachain-inherent 0.20.0",
- "cumulus-test-relay-sproof-builder 0.21.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-collator-selection 23.0.0",
- "pallet-session 42.0.0",
- "pallet-timestamp 41.0.0",
- "pallet-xcm 22.0.1",
- "parachains-common 24.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 18.0.0",
- "sp-consensus-aura 0.44.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
- "staging-parachain-info 0.22.0",
- "staging-xcm 18.0.0",
- "staging-xcm-executor 21.0.0",
- "xcm-runtime-apis 0.9.0",
+ "polkadot-parachain-primitives",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-tracing",
+ "staging-parachain-info",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -16972,12 +13699,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -17228,20 +13949,8 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4877ad0d359828f1e2aa6462a34b6424987d0c4bfde79ce9411144d80c8520c"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -17253,29 +13962,12 @@ dependencies = [
  "bounded-collections 0.3.2",
  "derive_more 0.99.20",
  "parity-scale-codec",
- "polkadot-core-primitives 7.0.0",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020fe431f0b594f4d6b22ecc62e86dfc03dc4cab727abcded1253dd44c27d952"
-dependencies = [
- "bounded-collections 0.3.2",
- "derive_more 0.99.20",
- "parity-scale-codec",
- "polkadot-core-primitives 19.0.0",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -17288,52 +13980,22 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 7.0.0",
- "polkadot-parachain-primitives 6.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-authority-discovery 26.0.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "polkadot-primitives"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e784fcdae5b2a8e889f4fb4ec9d2c993ec07a6a599247892d0efa3ce4a9e79f"
-dependencies = [
- "bitvec",
- "bounded-collections 0.3.2",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "polkadot-core-primitives 19.0.0",
- "polkadot-parachain-primitives 18.0.0",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-arithmetic 28.0.0",
- "sp-authority-discovery 38.0.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
  "thiserror 1.0.69",
 ]
 
@@ -17343,96 +14005,46 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bitvec",
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
- "pallet-asset-rate 7.0.0",
- "pallet-authorship 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-broker 0.6.0",
- "pallet-election-provider-multi-phase 27.0.0",
- "pallet-fast-unstake 27.0.0",
- "pallet-identity 29.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
- "pallet-staking-reward-fn 19.0.0",
- "pallet-timestamp 27.0.0",
- "pallet-transaction-payment 28.0.0",
- "pallet-treasury 27.0.0",
- "pallet-vesting 28.0.0",
+ "pallet-asset-rate",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-election-provider-multi-phase",
+ "pallet-fast-unstake",
+ "pallet-identity",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
- "slot-range-helper 7.0.0",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "polkadot-runtime-common"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b432d2cff7323d6f7e82ff201917b9fc918dbb011cbe0f069c43c8396ecaf4"
-dependencies = [
- "bitvec",
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "libsecp256k1",
- "log",
- "pallet-asset-rate 21.0.0",
- "pallet-authorship 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-broker 0.21.0",
- "pallet-election-provider-multi-phase 41.0.0",
- "pallet-fast-unstake 41.0.0",
- "pallet-identity 42.0.0",
- "pallet-session 42.0.0",
- "pallet-staking 42.0.0",
- "pallet-staking-reward-fn 24.0.0",
- "pallet-timestamp 41.0.0",
- "pallet-transaction-payment 42.0.0",
- "pallet-treasury 41.0.0",
- "pallet-vesting 42.0.0",
- "parity-scale-codec",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "rustc-hex",
- "scale-info",
- "serde",
- "slot-range-helper 19.0.0",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-keyring 43.0.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "slot-range-helper",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -17442,23 +14054,10 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bs58",
- "frame-benchmarking 28.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
- "polkadot-primitives 7.0.0",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "polkadot-runtime-metrics"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9672c198aa4eff49a7a9b9bf8e1755f2f76da459398fde6b2768325f31674bf"
-dependencies = [
- "bs58",
- "frame-benchmarking 42.0.0",
- "parity-scale-codec",
- "polkadot-primitives 20.0.0",
- "sp-tracing 18.0.0",
+ "polkadot-primitives",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -17468,92 +14067,44 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-authority-discovery 28.0.0",
- "pallet-authorship 28.0.0",
- "pallet-babe 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-broker 0.6.0",
- "pallet-message-queue 31.0.0",
- "pallet-mmr 27.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
- "pallet-timestamp 27.0.0",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-message-queue",
+ "pallet-mmr",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
  "parity-scale-codec",
- "polkadot-core-primitives 7.0.0",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-metrics 7.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-metrics",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "polkadot-runtime-parachains"
-version = "21.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bbe69378962effffbd00375055ab8d722613e494765f0e205053bbf8e3d9e"
-dependencies = [
- "bitflags 1.3.2",
- "bitvec",
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-authority-discovery 42.0.0",
- "pallet-authorship 42.0.0",
- "pallet-babe 42.0.0",
- "pallet-balances 43.0.1",
- "pallet-broker 0.21.0",
- "pallet-message-queue 45.0.0",
- "pallet-mmr 42.0.0",
- "pallet-session 42.0.0",
- "pallet-staking 42.0.0",
- "pallet-timestamp 41.0.0",
- "parity-scale-codec",
- "polkadot-core-primitives 19.0.0",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-metrics 22.0.0",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -17561,411 +14112,178 @@ name = "polkadot-sdk"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "asset-test-utils 7.0.0",
- "assets-common 0.7.0",
- "binary-merkle-tree 13.0.0",
- "bp-header-chain 0.7.0",
- "bp-messages 0.7.0",
- "bp-parachains 0.7.0",
- "bp-polkadot-core 0.7.0",
- "bp-relayers 0.7.0",
- "bp-runtime 0.7.0",
- "bp-test-utils 0.7.0",
- "bp-xcm-bridge-hub 0.2.0",
- "bp-xcm-bridge-hub-router 0.6.0",
- "bridge-hub-common 0.1.0",
- "bridge-hub-test-utils 0.7.0",
- "bridge-runtime-common 0.7.0",
- "cumulus-pallet-aura-ext 0.7.0",
- "cumulus-pallet-dmp-queue 0.7.0",
- "cumulus-pallet-parachain-system 0.7.0",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "cumulus-pallet-session-benchmarking 9.0.0",
- "cumulus-pallet-solo-to-para 0.7.0",
- "cumulus-pallet-weight-reclaim 1.0.0",
- "cumulus-pallet-xcm 0.7.0",
- "cumulus-pallet-xcmp-queue 0.7.1",
- "cumulus-ping 0.7.0",
- "cumulus-primitives-aura 0.7.0",
- "cumulus-primitives-core 0.7.0",
- "cumulus-primitives-parachain-inherent 0.7.0",
- "cumulus-primitives-proof-size-hostfunction 0.2.0",
- "cumulus-primitives-storage-weight-reclaim 1.0.0",
- "cumulus-primitives-timestamp 0.7.0",
- "cumulus-primitives-utility 0.7.0",
- "cumulus-test-relay-sproof-builder 0.7.0",
- "frame-benchmarking 28.0.0",
- "frame-benchmarking-pallet-pov 18.0.0",
- "frame-election-provider-solution-type 13.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-executive 28.0.0",
- "frame-metadata-hash-extension 0.1.0",
- "frame-support 28.0.0",
- "frame-support-procedural 23.0.0",
- "frame-support-procedural-tools-derive 11.0.0",
- "frame-system 28.0.0",
- "frame-system-benchmarking 28.0.0",
- "frame-system-rpc-runtime-api 26.0.0",
- "frame-try-runtime 0.34.0",
- "pallet-alliance 27.0.0",
- "pallet-asset-conversion 10.0.0",
- "pallet-asset-conversion-ops 0.1.0",
- "pallet-asset-conversion-tx-payment 10.0.0",
- "pallet-asset-rate 7.0.0",
- "pallet-asset-rewards 0.1.0",
- "pallet-asset-tx-payment 28.0.0",
- "pallet-assets 29.1.0",
- "pallet-assets-freezer 0.1.0",
- "pallet-assets-holder 0.1.0",
- "pallet-atomic-swap 28.0.0",
- "pallet-aura 27.0.0",
- "pallet-authority-discovery 28.0.0",
- "pallet-authorship 28.0.0",
- "pallet-babe 28.0.0",
- "pallet-bags-list 27.0.0",
- "pallet-balances 28.0.0",
- "pallet-beefy 28.0.0",
- "pallet-beefy-mmr 28.0.0",
- "pallet-bounties 27.0.0",
- "pallet-bridge-grandpa 0.7.0",
- "pallet-bridge-messages 0.7.0",
- "pallet-bridge-parachains 0.7.0",
- "pallet-bridge-relayers 0.7.0",
- "pallet-broker 0.6.0",
- "pallet-child-bounties 27.0.0",
- "pallet-collator-selection 9.0.0",
- "pallet-collective 28.0.0",
- "pallet-collective-content 0.6.0",
- "pallet-contracts 27.0.0",
- "pallet-contracts-mock-network 3.0.0",
- "pallet-conviction-voting 28.0.0",
- "pallet-core-fellowship 12.0.0",
- "pallet-delegated-staking 1.0.0",
- "pallet-democracy 28.0.0",
+ "asset-test-utils",
+ "assets-common",
+ "binary-merkle-tree",
+ "bp-header-chain",
+ "bp-messages",
+ "bp-parachains",
+ "bp-polkadot-core",
+ "bp-relayers",
+ "bp-runtime",
+ "bp-test-utils",
+ "bp-xcm-bridge-hub",
+ "bp-xcm-bridge-hub-router",
+ "bridge-hub-common",
+ "bridge-hub-test-utils",
+ "bridge-runtime-common",
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-solo-to-para",
+ "cumulus-pallet-weight-reclaim",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-ping",
+ "cumulus-primitives-aura",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-proof-size-hostfunction",
+ "cumulus-primitives-storage-weight-reclaim",
+ "cumulus-primitives-timestamp",
+ "cumulus-primitives-utility",
+ "cumulus-test-relay-sproof-builder",
+ "frame-benchmarking",
+ "frame-benchmarking-pallet-pov",
+ "frame-election-provider-solution-type",
+ "frame-election-provider-support",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-support-procedural-tools-derive",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "pallet-alliance",
+ "pallet-asset-conversion",
+ "pallet-asset-conversion-ops",
+ "pallet-asset-conversion-tx-payment",
+ "pallet-asset-rate",
+ "pallet-asset-rewards",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-assets-freezer",
+ "pallet-assets-holder",
+ "pallet-atomic-swap",
+ "pallet-aura",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-beefy",
+ "pallet-beefy-mmr",
+ "pallet-bounties",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-bridge-parachains",
+ "pallet-bridge-relayers",
+ "pallet-broker",
+ "pallet-child-bounties",
+ "pallet-collator-selection",
+ "pallet-collective",
+ "pallet-collective-content",
+ "pallet-contracts",
+ "pallet-contracts-mock-network",
+ "pallet-conviction-voting",
+ "pallet-core-fellowship",
+ "pallet-delegated-staking",
+ "pallet-democracy",
  "pallet-derivatives",
- "pallet-dev-mode 10.0.0",
- "pallet-dummy-dim 1.0.0",
- "pallet-election-provider-multi-block 0.9.0",
- "pallet-election-provider-multi-phase 27.0.0",
- "pallet-election-provider-support-benchmarking 27.0.0",
- "pallet-elections-phragmen 29.0.0",
- "pallet-fast-unstake 27.0.0",
- "pallet-glutton 14.0.0",
- "pallet-grandpa 28.0.0",
- "pallet-identity 29.0.0",
- "pallet-im-online 27.0.0",
- "pallet-indices 28.0.0",
- "pallet-insecure-randomness-collective-flip 16.0.0",
- "pallet-lottery 28.0.0",
- "pallet-membership 28.0.0",
- "pallet-message-queue 31.0.0",
- "pallet-meta-tx 0.1.0",
- "pallet-migrations 1.0.0",
- "pallet-mixnet 0.4.0",
- "pallet-mmr 27.0.0",
- "pallet-multisig 28.0.0",
- "pallet-nft-fractionalization 10.0.0",
- "pallet-nfts 22.0.0",
- "pallet-nfts-runtime-api 14.0.0",
- "pallet-nis 28.0.0",
- "pallet-node-authorization 28.0.0",
- "pallet-nomination-pools 25.0.0",
- "pallet-nomination-pools-benchmarking 26.0.0",
- "pallet-nomination-pools-runtime-api 23.0.0",
- "pallet-offences 27.0.0",
- "pallet-offences-benchmarking 28.0.0",
- "pallet-origin-restriction 1.0.0",
- "pallet-paged-list 0.6.0",
- "pallet-parameters 0.1.0",
- "pallet-people 1.0.0",
- "pallet-preimage 28.0.0",
- "pallet-proxy 28.0.0",
- "pallet-ranked-collective 28.0.0",
- "pallet-recovery 28.0.0",
- "pallet-referenda 28.0.0",
- "pallet-remark 28.0.0",
- "pallet-revive 0.1.0",
- "pallet-root-offences 25.0.0",
- "pallet-root-testing 4.0.0",
- "pallet-safe-mode 9.0.0",
- "pallet-salary 13.0.0",
- "pallet-scheduler 29.0.0",
- "pallet-scored-pool 28.0.0",
- "pallet-session 28.0.0",
- "pallet-session-benchmarking 28.0.0",
- "pallet-skip-feeless-payment 3.0.0",
- "pallet-society 28.0.0",
- "pallet-staking 28.0.0",
- "pallet-staking-async 0.1.0",
- "pallet-staking-async-ah-client 0.1.0",
- "pallet-staking-async-rc-client 0.1.0",
- "pallet-staking-async-reward-fn 19.0.0",
- "pallet-staking-async-runtime-api 14.0.0",
- "pallet-staking-reward-fn 19.0.0",
- "pallet-staking-runtime-api 14.0.0",
- "pallet-state-trie-migration 29.0.0",
- "pallet-statement 10.0.0",
- "pallet-sudo 28.0.0",
- "pallet-timestamp 27.0.0",
- "pallet-tips 27.0.0",
- "pallet-transaction-payment 28.0.0",
- "pallet-transaction-payment-rpc-runtime-api 28.0.0",
- "pallet-transaction-storage 27.0.0",
- "pallet-treasury 27.0.0",
- "pallet-tx-pause 9.0.0",
- "pallet-uniques 28.0.0",
- "pallet-utility 28.0.0",
- "pallet-verify-signature 1.0.0",
- "pallet-vesting 28.0.0",
- "pallet-whitelist 27.0.0",
- "pallet-xcm 7.0.0",
- "pallet-xcm-benchmarks 7.0.0",
- "pallet-xcm-bridge-hub 0.2.0",
- "pallet-xcm-bridge-hub-router 0.5.0",
- "parachains-common 7.0.0",
- "parachains-runtimes-test-utils 7.0.0",
- "polkadot-core-primitives 7.0.0",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-common 7.0.0",
- "polkadot-runtime-metrics 7.0.0",
- "polkadot-runtime-parachains 7.0.0",
- "polkadot-sdk-frame 0.1.0",
- "sc-executor 0.32.0",
- "slot-range-helper 7.0.0",
- "sp-api 26.0.0",
- "sp-api-proc-macro 15.0.0",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-authority-discovery 26.0.0",
- "sp-block-builder 26.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-consensus-babe 0.32.0",
- "sp-consensus-beefy 13.0.0",
- "sp-consensus-grandpa 13.0.0",
- "sp-consensus-pow 0.32.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-core-hashing 15.0.0",
- "sp-crypto-ec-utils 0.10.0",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-externalities 0.25.0",
- "sp-genesis-builder 0.8.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-metadata-ir 0.6.0",
- "sp-mixnet 0.4.0",
- "sp-mmr-primitives 26.0.0",
- "sp-npos-elections 26.0.0",
- "sp-offchain 26.0.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "sp-runtime-interface-proc-macro 17.0.0",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
- "sp-state-machine 0.35.0",
- "sp-statement-store 10.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-storage 19.0.0",
- "sp-timestamp 26.0.0",
- "sp-tracing 16.0.0",
- "sp-transaction-pool 26.0.0",
- "sp-transaction-storage-proof 26.0.0",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "sp-version-proc-macro 13.0.0",
- "sp-wasm-interface 20.0.0",
- "sp-weights 27.0.0",
- "staging-parachain-info 0.7.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
- "substrate-bip39 0.4.7",
- "testnet-parachains-constants 1.0.0",
- "xcm-runtime-apis 0.1.1",
-]
-
-[[package]]
-name = "polkadot-sdk"
-version = "2507.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b2eed0fc29543d16b2225c34422a0a69fc0ba4f319e161ca6a8f4531f92c7"
-dependencies = [
- "asset-test-utils 26.0.1",
- "assets-common 0.24.0",
- "binary-merkle-tree 16.0.0",
- "bp-header-chain 0.22.0",
- "bp-messages 0.22.0",
- "bp-parachains 0.22.0",
- "bp-polkadot-core 0.22.0",
- "bp-relayers 0.22.0",
- "bp-runtime 0.22.0",
- "bp-test-utils 0.22.0",
- "bp-xcm-bridge-hub 0.8.0",
- "bp-xcm-bridge-hub-router 0.19.0",
- "bridge-hub-common 0.15.0",
- "bridge-hub-test-utils 0.25.0",
- "bridge-runtime-common 0.23.0",
- "cumulus-pallet-aura-ext 0.22.0",
- "cumulus-pallet-dmp-queue 0.22.0",
- "cumulus-pallet-parachain-system 0.22.1",
- "cumulus-pallet-parachain-system-proc-macro 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cumulus-pallet-session-benchmarking 23.0.0",
- "cumulus-pallet-solo-to-para 0.22.0",
- "cumulus-pallet-weight-reclaim 0.4.0",
- "cumulus-pallet-xcm 0.21.0",
- "cumulus-pallet-xcmp-queue 0.22.1",
- "cumulus-ping 0.22.0",
- "cumulus-primitives-aura 0.19.0",
- "cumulus-primitives-core 0.20.0",
- "cumulus-primitives-parachain-inherent 0.20.0",
- "cumulus-primitives-proof-size-hostfunction 0.14.0",
- "cumulus-primitives-storage-weight-reclaim 13.0.0",
- "cumulus-primitives-timestamp 0.21.0",
- "cumulus-primitives-utility 0.22.0",
- "cumulus-test-relay-sproof-builder 0.21.0",
- "frame-benchmarking 42.0.0",
- "frame-benchmarking-pallet-pov 32.0.0",
- "frame-election-provider-solution-type 16.1.1",
- "frame-election-provider-support 42.0.0",
- "frame-executive 42.0.1",
- "frame-metadata-hash-extension 0.10.0",
- "frame-support 42.0.0",
- "frame-support-procedural 35.0.0",
- "frame-support-procedural-tools-derive 12.0.0",
- "frame-system 42.0.0",
- "frame-system-benchmarking 42.0.0",
- "frame-system-rpc-runtime-api 38.0.0",
- "frame-try-runtime 0.48.0",
- "pallet-alliance 41.0.0",
- "pallet-asset-conversion 24.0.0",
- "pallet-asset-conversion-ops 0.10.0",
- "pallet-asset-conversion-tx-payment 24.0.0",
- "pallet-asset-rate 21.0.0",
- "pallet-asset-rewards 0.4.0",
- "pallet-asset-tx-payment 42.0.0",
- "pallet-assets 45.0.0",
- "pallet-assets-freezer 0.10.0",
- "pallet-assets-holder 0.5.0",
- "pallet-atomic-swap 42.0.0",
- "pallet-aura 41.0.0",
- "pallet-authority-discovery 42.0.0",
- "pallet-authorship 42.0.0",
- "pallet-babe 42.0.0",
- "pallet-bags-list 41.0.0",
- "pallet-balances 43.0.1",
- "pallet-beefy 43.0.0",
- "pallet-beefy-mmr 43.0.0",
- "pallet-bounties 41.0.0",
- "pallet-bridge-grandpa 0.22.0",
- "pallet-bridge-messages 0.22.0",
- "pallet-bridge-parachains 0.22.0",
- "pallet-bridge-relayers 0.22.0",
- "pallet-broker 0.21.0",
- "pallet-child-bounties 41.0.0",
- "pallet-collator-selection 23.0.0",
- "pallet-collective 42.0.0",
- "pallet-collective-content 0.20.0",
- "pallet-contracts 42.0.0",
- "pallet-contracts-mock-network 20.0.0",
- "pallet-conviction-voting 42.0.0",
- "pallet-core-fellowship 26.0.1",
- "pallet-delegated-staking 9.0.0",
- "pallet-democracy 42.0.0",
- "pallet-dev-mode 24.0.0",
- "pallet-dummy-dim 0.3.0",
- "pallet-election-provider-multi-block 0.3.1",
- "pallet-election-provider-multi-phase 41.0.0",
- "pallet-election-provider-support-benchmarking 41.0.0",
- "pallet-elections-phragmen 43.0.0",
- "pallet-fast-unstake 41.0.0",
- "pallet-glutton 28.0.0",
- "pallet-grandpa 42.0.0",
- "pallet-identity 42.0.0",
- "pallet-im-online 41.0.0",
- "pallet-indices 42.0.0",
- "pallet-insecure-randomness-collective-flip 30.0.0",
- "pallet-lottery 42.0.0",
- "pallet-membership 42.0.0",
- "pallet-message-queue 45.0.0",
- "pallet-meta-tx 0.4.0",
- "pallet-migrations 12.0.0",
- "pallet-mixnet 0.18.0",
- "pallet-mmr 42.0.0",
- "pallet-multisig 42.0.0",
- "pallet-nft-fractionalization 26.0.0",
- "pallet-nfts 36.0.0",
- "pallet-nfts-runtime-api 28.0.0",
- "pallet-nis 42.0.0",
- "pallet-node-authorization 42.0.0",
- "pallet-nomination-pools 40.0.0",
- "pallet-nomination-pools-benchmarking 40.0.0",
- "pallet-nomination-pools-runtime-api 38.0.0",
- "pallet-offences 41.0.0",
- "pallet-offences-benchmarking 42.0.0",
- "pallet-origin-restriction 0.3.0",
- "pallet-paged-list 0.20.0",
- "pallet-parameters 0.13.0",
- "pallet-people 0.3.0",
- "pallet-preimage 42.0.0",
- "pallet-proxy 42.0.0",
- "pallet-ranked-collective 42.0.0",
- "pallet-recovery 42.0.0",
- "pallet-referenda 42.0.0",
- "pallet-remark 42.0.0",
- "pallet-revive 0.9.0",
+ "pallet-dev-mode",
+ "pallet-dummy-dim",
+ "pallet-election-provider-multi-block",
+ "pallet-election-provider-multi-phase",
+ "pallet-election-provider-support-benchmarking",
+ "pallet-elections-phragmen",
+ "pallet-fast-unstake",
+ "pallet-glutton",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-insecure-randomness-collective-flip",
+ "pallet-lottery",
+ "pallet-membership",
+ "pallet-message-queue",
+ "pallet-meta-tx",
+ "pallet-migrations",
+ "pallet-mixnet",
+ "pallet-mmr",
+ "pallet-multisig",
+ "pallet-nft-fractionalization",
+ "pallet-nfts",
+ "pallet-nfts-runtime-api",
+ "pallet-nis",
+ "pallet-node-authorization",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
+ "pallet-offences",
+ "pallet-offences-benchmarking",
+ "pallet-origin-restriction",
+ "pallet-paged-list",
+ "pallet-parameters",
+ "pallet-people",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-ranked-collective",
+ "pallet-recovery",
+ "pallet-referenda",
+ "pallet-remark",
+ "pallet-revive",
  "pallet-revive-eth-rpc",
- "pallet-root-offences 39.0.0",
- "pallet-root-testing 18.0.0",
- "pallet-safe-mode 23.0.0",
- "pallet-salary 27.0.0",
- "pallet-scheduler 43.0.0",
- "pallet-scored-pool 42.0.0",
- "pallet-session 42.0.0",
- "pallet-session-benchmarking 42.0.0",
- "pallet-skip-feeless-payment 17.0.0",
- "pallet-society 42.2.0",
- "pallet-staking 42.0.0",
- "pallet-staking-async 0.4.2",
- "pallet-staking-async-ah-client 0.3.0",
- "pallet-staking-async-rc-client 0.3.0",
- "pallet-staking-async-reward-fn 0.3.0",
- "pallet-staking-async-runtime-api 0.3.0",
- "pallet-staking-reward-fn 24.0.0",
- "pallet-staking-runtime-api 28.0.0",
- "pallet-state-trie-migration 47.0.0",
- "pallet-statement 24.0.0",
- "pallet-sudo 42.0.0",
- "pallet-timestamp 41.0.0",
- "pallet-tips 41.0.0",
- "pallet-transaction-payment 42.0.0",
- "pallet-transaction-payment-rpc-runtime-api 42.0.0",
- "pallet-transaction-storage 41.0.0",
- "pallet-treasury 41.0.0",
- "pallet-tx-pause 23.0.0",
- "pallet-uniques 42.0.0",
- "pallet-utility 42.0.0",
- "pallet-verify-signature 0.5.0",
- "pallet-vesting 42.0.0",
- "pallet-whitelist 41.0.0",
- "pallet-xcm 22.0.1",
- "pallet-xcm-benchmarks 22.0.0",
- "pallet-xcm-bridge-hub 0.18.0",
- "pallet-xcm-bridge-hub-router 0.20.0",
- "parachains-common 24.0.0",
- "parachains-runtimes-test-utils 25.0.0",
- "polkadot-core-primitives 19.0.0",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-common 21.0.0",
- "polkadot-runtime-metrics 22.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "polkadot-sdk-frame 0.11.0",
- "sc-allocator 33.0.0",
+ "pallet-root-offences",
+ "pallet-root-testing",
+ "pallet-safe-mode",
+ "pallet-salary",
+ "pallet-scheduler",
+ "pallet-scored-pool",
+ "pallet-session",
+ "pallet-session-benchmarking",
+ "pallet-skip-feeless-payment",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-staking-async",
+ "pallet-staking-async-ah-client",
+ "pallet-staking-async-rc-client",
+ "pallet-staking-async-reward-fn",
+ "pallet-staking-async-runtime-api",
+ "pallet-staking-reward-fn",
+ "pallet-staking-runtime-api",
+ "pallet-state-trie-migration",
+ "pallet-statement",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-tips",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-transaction-storage",
+ "pallet-treasury",
+ "pallet-tx-pause",
+ "pallet-uniques",
+ "pallet-utility",
+ "pallet-verify-signature",
+ "pallet-vesting",
+ "pallet-whitelist",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
+ "pallet-xcm-bridge-hub",
+ "pallet-xcm-bridge-hub-router",
+ "parachains-common",
+ "parachains-runtimes-test-utils",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-metrics",
+ "polkadot-runtime-parachains",
+ "polkadot-sdk-frame",
+ "sc-allocator",
  "sc-basic-authorship",
  "sc-block-builder",
  "sc-chain-spec",
@@ -17974,9 +14292,9 @@ dependencies = [
  "sc-client-db",
  "sc-consensus",
  "sc-consensus-manual-seal",
- "sc-executor 0.44.0",
- "sc-executor-common 0.40.0",
- "sc-executor-wasmtime 0.40.0",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
  "sc-keystore",
  "sc-network-types",
  "sc-rpc",
@@ -17989,71 +14307,71 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sc-utils",
- "slot-range-helper 19.0.0",
- "sp-api 38.0.0",
- "sp-api-proc-macro 24.0.0",
- "sp-application-crypto 42.0.0",
- "sp-arithmetic 28.0.0",
- "sp-authority-discovery 38.0.0",
- "sp-block-builder 38.0.0",
+ "slot-range-helper",
+ "sp-api",
+ "sp-api-proc-macro",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.44.0",
- "sp-consensus-babe 0.44.0",
- "sp-consensus-beefy 26.0.0",
- "sp-consensus-grandpa 25.0.0",
- "sp-consensus-pow 0.44.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-core-hashing 16.0.0",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-consensus-grandpa",
+ "sp-consensus-pow",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-core-hashing",
  "sp-core-hashing-proc-macro",
- "sp-crypto-ec-utils 0.17.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-ec-utils",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-crypto-hashing-proc-macro",
  "sp-database",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.30.0",
- "sp-genesis-builder 0.19.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-keyring 43.0.0",
- "sp-keystore 0.44.0",
- "sp-metadata-ir 0.12.0",
- "sp-mixnet 0.16.0",
- "sp-mmr-primitives 38.0.0",
- "sp-npos-elections 38.0.0",
- "sp-offchain 38.0.0",
- "sp-panic-handler 13.0.2",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-metadata-ir",
+ "sp-mixnet",
+ "sp-mmr-primitives",
+ "sp-npos-elections",
+ "sp-offchain",
+ "sp-panic-handler",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-runtime-interface-proc-macro 20.0.0",
- "sp-session 40.0.0",
- "sp-staking 40.0.0",
- "sp-state-machine 0.47.0",
- "sp-statement-store 22.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 22.0.0",
- "sp-timestamp 38.0.0",
- "sp-tracing 18.0.0",
- "sp-transaction-pool 38.0.0",
- "sp-transaction-storage-proof 38.0.0",
- "sp-trie 41.0.0",
- "sp-version 41.0.0",
- "sp-version-proc-macro 15.0.0",
- "sp-wasm-interface 23.0.0",
- "sp-weights 33.0.0",
- "staging-parachain-info 0.22.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
- "substrate-bip39 0.6.0",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-runtime-interface-proc-macro",
+ "sp-session",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-statement-store",
+ "sp-std",
+ "sp-storage",
+ "sp-timestamp",
+ "sp-tracing",
+ "sp-transaction-pool",
+ "sp-transaction-storage-proof",
+ "sp-trie",
+ "sp-version",
+ "sp-version-proc-macro",
+ "sp-wasm-interface",
+ "sp-weights",
+ "staging-parachain-info",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "substrate-bip39",
  "substrate-frame-rpc-support",
  "substrate-frame-rpc-system",
  "substrate-rpc-client",
  "substrate-wasm-builder",
- "testnet-parachains-constants 15.0.0",
- "xcm-runtime-apis 0.9.0",
+ "testnet-parachains-constants",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -18062,69 +14380,33 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-executive 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "frame-system-benchmarking 28.0.0",
- "frame-system-rpc-runtime-api 26.0.0",
- "frame-try-runtime 0.34.0",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-arithmetic 23.0.0",
- "sp-block-builder 26.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-consensus-grandpa 13.0.0",
- "sp-core 28.0.0",
- "sp-genesis-builder 0.8.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-keyring 31.0.0",
- "sp-offchain 26.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-storage 19.0.0",
- "sp-transaction-pool 26.0.0",
- "sp-version 29.0.0",
-]
-
-[[package]]
-name = "polkadot-sdk-frame"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59656beb1ce1f0373e10ac96846aa1d5169969852748913311001e0b68a24293"
-dependencies = [
- "docify",
- "frame-benchmarking 42.0.0",
- "frame-executive 42.0.1",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "frame-system-benchmarking 42.0.0",
- "frame-system-rpc-runtime-api 38.0.0",
- "frame-try-runtime 0.48.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-arithmetic 28.0.0",
- "sp-block-builder 38.0.0",
- "sp-consensus-aura 0.44.0",
- "sp-consensus-grandpa 25.0.0",
- "sp-core 38.0.0",
- "sp-genesis-builder 0.19.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-keyring 43.0.0",
- "sp-offchain 38.0.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 38.0.0",
- "sp-version 41.0.0",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-storage",
+ "sp-transaction-pool",
+ "sp-version",
 ]
 
 [[package]]
@@ -18261,10 +14543,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beb896023e5bd89bba40311797d8d42490fa4a1fd5256c74820753c5722d1e67"
 dependencies = [
  "dirs 5.0.1",
- "gimli 0.31.1",
+ "gimli",
  "hashbrown 0.14.5",
  "log",
- "object 0.36.7",
+ "object",
  "polkavm-common 0.26.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
@@ -18277,10 +14559,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99fe3704d21e96c5d1e6a1b1a43ac57f9dce110d3331fbf8299e9f57d5884066"
 dependencies = [
  "dirs 5.0.1",
- "gimli 0.31.1",
+ "gimli",
  "hashbrown 0.14.5",
  "log",
- "object 0.36.7",
+ "object",
  "polkavm-common 0.27.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
@@ -18306,7 +14588,7 @@ checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
@@ -19178,18 +15460,6 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
-dependencies = [
- "fxhash",
- "log",
- "slice-group-by",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
@@ -19321,7 +15591,7 @@ name = "revive-env"
 version = "1.3.6"
 dependencies = [
  "parity-scale-codec",
- "polkadot-sdk 0.1.0",
+ "polkadot-sdk",
  "scale-info",
 ]
 
@@ -19356,7 +15626,7 @@ dependencies = [
  "foundry-linking",
  "itertools 0.14.0",
  "parity-scale-codec",
- "polkadot-sdk 0.1.0",
+ "polkadot-sdk",
  "revive-env",
  "revm",
  "scale-info",
@@ -19642,9 +15912,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -19655,32 +15925,15 @@ name = "rococo-runtime-constants"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-common 7.0.0",
+ "frame-support",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
-]
-
-[[package]]
-name = "rococo-runtime-constants"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29599de346cfb44bb58a4239db7a328a13ee951dea51d89996ae916c7df444fd"
-dependencies = [
- "frame-support 42.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-common 21.0.0",
- "smallvec",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -19876,21 +16129,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -20057,6 +16296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+
+[[package]]
 name = "rvm-rs"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20145,28 +16390,15 @@ version = "23.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "sp-core 28.0.0",
- "sp-wasm-interface 20.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sc-allocator"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329ce3b230fd59149df2743291a2e1f58ea769eb87e2678ea11e00d118b7cc0"
-dependencies = [
- "log",
- "sp-core 38.0.0",
- "sp-wasm-interface 23.0.0",
+ "sp-core",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af310d69ec9c19bde9ccf3ce1c7408db52b260f2924cc502d9dd3a1de569f19"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "futures",
  "log",
@@ -20175,36 +16407,35 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c73910b6c3d0520d26b13c91987b437a9e81692f70f6a4f48221db27828405"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-block-builder 38.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-trie 41.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb879d2450ce27cd1e5ff298f83ba4ed1d96510ec81d3de8d7d1586c904bd21"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "docify",
@@ -20212,26 +16443,25 @@ dependencies = [
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
- "sc-executor 0.44.0",
+ "sc-executor",
  "sc-network",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-genesis-builder 0.19.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-tracing 18.0.0",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -20241,9 +16471,8 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2a4b8400da0a31db7f673b983aab11eea02a4bbd027cc29fde23bac6a21903"
+version = "0.36.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -20272,48 +16501,46 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-keyring 43.0.0",
- "sp-keystore 0.44.0",
- "sp-panic-handler 13.0.2",
- "sp-runtime 43.0.0",
- "sp-version 41.0.0",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-panic-handler",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2becab28c1cac3fb676fe5be71ce74d4c80b901a3b659da0711a7cb0e2813f"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.4",
- "sc-executor 0.44.0",
+ "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.30.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-storage 22.0.0",
- "sp-trie 41.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-trie",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bfbc7c68babcf07db50701a3b3bcdc90ccb4fe9bb3608741019c416a03332a"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -20327,22 +16554,21 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-database",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "sp-trie 41.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+ "substrate-prometheus-endpoint",
  "sysinfo",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66267c1d256a2eaf8c414fd2737e7c88cd3aa44140e939853b03b7030baf1886"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "futures",
@@ -20355,48 +16581,48 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c497a246929b735502956f1cec7a5fe6841a9812c19c8d8520b0d92a8f5b08b1"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
+ "fork-tree",
  "futures",
  "log",
  "parity-scale-codec",
+ "parking_lot 0.12.4",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-block-builder 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.44.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2fa506e3557493e52ed361c3fc6c55a1bfc0dfef72c70ab07c1005d7219f1b"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -20413,41 +16639,40 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-block-builder 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-babe 0.44.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 38.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9190ea2a128c1f4c5765f16b0eeb16dafb8a1edeb5de634950b23e75b90abd5"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a96e98893fbc7fb03163809ce9df83a3bdbc5363c571338d44a0d03605bf638"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -20464,26 +16689,25 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.44.0",
- "sp-consensus-babe 0.44.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-timestamp 38.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642c7115caa8a12a1c32319607334bbee33b10d87f719da99b5a13ae3b0ab6dc"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "futures",
@@ -20493,14 +16717,14 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -20510,43 +16734,19 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
- "sc-executor-common 0.29.0",
- "sc-executor-polkavm 0.29.0",
- "sc-executor-wasmtime 0.29.0",
+ "sc-executor-common",
+ "sc-executor-polkavm",
+ "sc-executor-wasmtime",
  "schnellru",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-io 30.0.0",
- "sp-panic-handler 13.0.0",
- "sp-runtime-interface 24.0.0",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "sp-wasm-interface 20.0.0",
- "tracing",
-]
-
-[[package]]
-name = "sc-executor"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9208cad4fa8142858cd02237205a9792d2819f7c0563d2b28d7bbf2d12dd430a"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "sc-executor-common 0.40.0",
- "sc-executor-polkavm 0.37.0",
- "sc-executor-wasmtime 0.40.0",
- "schnellru",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "sp-io 42.0.0",
- "sp-panic-handler 13.0.2",
- "sp-runtime-interface 31.0.0",
- "sp-trie 41.0.0",
- "sp-version 41.0.0",
- "sp-wasm-interface 23.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-panic-handler",
+ "sp-runtime-interface",
+ "sp-trie",
+ "sp-version",
+ "sp-wasm-interface",
  "tracing",
 ]
 
@@ -20556,23 +16756,9 @@ version = "0.29.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "polkavm 0.26.0",
- "sc-allocator 23.0.0",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-wasm-interface 20.0.0",
- "thiserror 1.0.69",
- "wasm-instrument",
-]
-
-[[package]]
-name = "sc-executor-common"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88ba9c113644a21ce48cfecd8f2c99a34a1b3f8a869fb91c0e6a5c72c3a7ac8"
-dependencies = [
- "polkavm 0.26.0",
- "sc-allocator 33.0.0",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 23.0.0",
+ "sc-allocator",
+ "sp-maybe-compressed-blob",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
@@ -20584,20 +16770,8 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "log",
  "polkavm 0.26.0",
- "sc-executor-common 0.29.0",
- "sp-wasm-interface 20.0.0",
-]
-
-[[package]]
-name = "sc-executor-polkavm"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d4405eff470c6b20e883bc6e7ad855130ac5c99ada0f2265191e21caa2fd85"
-dependencies = [
- "log",
- "polkavm 0.26.0",
- "sc-executor-common 0.40.0",
- "sp-wasm-interface 23.0.0",
+ "sc-executor-common",
+ "sp-wasm-interface",
 ]
 
 [[package]]
@@ -20609,35 +16783,17 @@ dependencies = [
  "log",
  "parking_lot 0.12.4",
  "rustix 1.0.8",
- "sc-allocator 23.0.0",
- "sc-executor-common 0.29.0",
- "sp-runtime-interface 24.0.0",
- "sp-wasm-interface 20.0.0",
- "wasmtime 35.0.0",
-]
-
-[[package]]
-name = "sc-executor-wasmtime"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250e3469323c427bcf4402909731c07f71e93d3314ffdbbe57c683e8c9349615"
-dependencies = [
- "anyhow",
- "log",
- "parking_lot 0.12.4",
- "rustix 0.36.17",
- "sc-allocator 33.0.0",
- "sc-executor-common 0.40.0",
- "sp-runtime-interface 31.0.0",
- "sp-wasm-interface 23.0.0",
- "wasmtime 8.0.1",
+ "sc-allocator",
+ "sc-executor-common",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
+ "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2098bbe627dd269e93f44755a18bd9a7d6a9e610614a609d802471a47163f4ca"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "console",
  "futures",
@@ -20647,29 +16803,27 @@ dependencies = [
  "sc-network",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e70b8b849bd7001425c65954c175e73dcc1209a98a321d79975d1cc012895b"
+version = "25.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.4",
  "serde_json",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-keystore 0.44.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf56b48703fc41cf1a6c0bc05dd3d3a0c1b71dd111f0629c996af5e270b97d8"
+version = "0.4.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -20685,20 +16839,19 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-core 38.0.0",
- "sp-keystore 0.44.0",
- "sp-mixnet 0.16.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-mixnet",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe306580ae405c1a866edc4d9339cbd348005f0bdbd32aaa36d840dfd0f991e3"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -20731,11 +16884,11 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-core",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -20747,20 +16900,18 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f006ff1f1f5cd1b254323bb1eeedce27927f851a44028d1ecdaf9e8a1f672c90"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b44abe92cfaabd84d1ba452d789acc9faa20d0477c214144579ef5322b15f9"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -20773,16 +16924,15 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cc1e02d4cdd4b31e4bc2dae9d80ee4d7fcb04d0e4c7909f6b91d51668f28f3"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -20802,13 +16952,13 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-grandpa 25.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -20816,9 +16966,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadfb62930bbf1e70b80df50e7089d0665a13bc12f5bd89997f12140bc242814"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "futures",
@@ -20830,15 +16979,14 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 43.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-network-types"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f883c5f12300eac2bbcf86f856316bafe4993284db3589e2b515bf279b22f"
+version = "0.10.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "bs58",
  "bytes",
@@ -20858,19 +17006,17 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872046dabf12aef8cdc6a67a9c5bcb4fc34fb7f2d8a664ed2028aaf2717895f1"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
- "substrate-prometheus-endpoint 0.17.7",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-rpc"
-version = "47.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a86644819c961db3ab7a96c97b3aa4110195859d28b8b1f75269ba9081d58b"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -20886,24 +17032,23 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-keystore 0.44.0",
- "sp-offchain 38.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-offchain",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-statement-store 22.0.0",
- "sp-version 41.0.0",
+ "sp-runtime",
+ "sp-session",
+ "sp-statement-store",
+ "sp-version",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2097100944856f8f0dcc6dcda719397117bb68a576464395be513a2caf870f"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -20913,18 +17058,17 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-version 41.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d65e50b5ef8459df5d397addeb671f1e7dbe24dbff4ff4e37a4e22848f641b3"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -20939,7 +17083,7 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "serde_json",
- "substrate-prometheus-endpoint 0.17.7",
+ "substrate-prometheus-endpoint",
  "tokio",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -20947,9 +17091,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226834bbd274e2af0194232c6dc1af28c679b97cb5e62dd0af33340f508c4a0a"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "array-bytes",
  "futures",
@@ -20967,13 +17110,13 @@ dependencies = [
  "sc-transaction-pool-api",
  "schnellru",
  "serde",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-version 41.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-runtime",
+ "sp-version",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -20981,9 +17124,8 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3e2d7352ddb9ed2b412a641c19cc3ce0147c0b6017a42e5cf5dd5c85baf28d"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "directories",
@@ -21000,7 +17142,7 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
- "sc-executor 0.44.0",
+ "sc-executor",
  "sc-informant",
  "sc-keystore",
  "sc-network",
@@ -21021,22 +17163,22 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-session 40.0.0",
- "sp-state-machine 0.47.0",
- "sp-storage 22.0.0",
- "sp-transaction-pool 38.0.0",
- "sp-transaction-storage-proof 38.0.0",
- "sp-trie 41.0.0",
- "sp-version 41.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-transaction-pool",
+ "sp-transaction-storage-proof",
+ "sp-trie",
+ "sp-version",
  "static_init",
- "substrate-prometheus-endpoint 0.17.7",
+ "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -21046,21 +17188,19 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f19abd85a7a55412f17e7a3da319e42816532c2a07eb94abcec0232a896edf"
+version = "0.30.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.4",
- "sp-core 38.0.0",
+ "sp-core",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39681b4640d02d9a2897248f4602752c62ee31409c6644c44c0c4425ad2233e"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -21072,16 +17212,15 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 42.0.0",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661460d41cb14de3d8ad638bc34f9179eb2dd65791ccf71fa6dc0c572ad8100b"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "chrono",
  "futures",
@@ -21099,9 +17238,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58f33921adc28c139df6b98a1756284bfd73f6d7a41d0f853fc469a9ae5984b"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "chrono",
  "console",
@@ -21114,12 +17252,12 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
+ "sp-runtime",
+ "sp-tracing",
  "thiserror 1.0.69",
  "tracing",
  "tracing-log",
@@ -21128,9 +17266,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing-proc-macro"
-version = "11.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb090b3a15c077b029619476b682ba8a31f391ee3f0b2c5f3f24366f53f6c538"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -21140,9 +17277,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3149dd24664e7900a9f07e27c9d22ce55236ae54081c844965a293ed32cb6a"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "futures",
@@ -21156,14 +17292,14 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 43.0.0",
- "sp-tracing 18.0.0",
- "sp-transaction-pool 38.0.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
+ "sp-runtime",
+ "sp-tracing",
+ "sp-transaction-pool",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -21172,9 +17308,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576c5443c7ccaa907e03b2c167d4f9f64168d638261b6ac1a08dcd30c3811862"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "futures",
@@ -21183,16 +17318,15 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-utils"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58dbfbc4408b0d210a6b7099c07caf02001e6975f62e316ea5b5c1f5c2108f4"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -21200,7 +17334,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.4",
  "prometheus",
- "sp-arithmetic 28.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -22102,19 +18236,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "slot-range-helper"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b143ebffebf7b7cfbcaa72dcdbd7ff77d16a96f3a7531649273540cfaac647"
-dependencies = [
- "enumn",
- "parity-scale-codec",
- "paste",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -22178,7 +18300,7 @@ dependencies = [
  "libm",
  "libsecp256k1",
  "merlin",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -22187,7 +18309,7 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "ruzstd",
+ "ruzstd 0.6.0",
  "schnorrkel 0.11.5",
  "serde",
  "serde_json",
@@ -22197,8 +18319,62 @@ dependencies = [
  "slab",
  "smallvec",
  "soketto",
- "twox-hash",
- "wasmi",
+ "twox-hash 1.6.3",
+ "wasmi 0.32.3",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16e5723359f0048bf64bfdfba64e5732a56847d42c4fd3fe56f18280c813413"
+dependencies = [
+ "arrayvec 0.7.6",
+ "async-lock",
+ "atomic-take",
+ "base64 0.22.1",
+ "bip39",
+ "blake2-rfc",
+ "bs58",
+ "chacha20",
+ "crossbeam-queue",
+ "derive_more 2.0.1",
+ "ed25519-zebra",
+ "either",
+ "event-listener 5.4.1",
+ "fnv",
+ "futures-lite",
+ "futures-util",
+ "hashbrown 0.15.4",
+ "hex",
+ "hmac 0.12.1",
+ "itertools 0.14.0",
+ "libm",
+ "libsecp256k1",
+ "merlin",
+ "nom 8.0.0",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "pbkdf2 0.12.2",
+ "pin-project 1.1.10",
+ "poly1305",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd 0.8.1",
+ "schnorrkel 0.11.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "siphasher 1.0.1",
+ "slab",
+ "smallvec",
+ "soketto",
+ "twox-hash 2.1.2",
+ "wasmi 0.40.0",
  "x25519-dalek",
  "zeroize",
 ]
@@ -22235,7 +18411,43 @@ dependencies = [
  "siphasher 1.0.1",
  "slab",
  "smol",
- "smoldot",
+ "smoldot 0.18.0",
+ "zeroize",
+]
+
+[[package]]
+name = "smoldot-light"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bba9e591716567d704a8252feeb2f1261a286e1e2cbdd4e49e9197c34a14e2"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-lock",
+ "base64 0.22.1",
+ "blake2-rfc",
+ "bs58",
+ "derive_more 2.0.1",
+ "either",
+ "event-listener 5.4.1",
+ "fnv",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "hashbrown 0.15.4",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "lru 0.12.5",
+ "parking_lot 0.12.4",
+ "pin-project 1.1.10",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.1",
+ "slab",
+ "smol",
+ "smoldot 0.19.4",
  "zeroize",
 ]
 
@@ -22293,48 +18505,23 @@ name = "snowbridge-core"
 version = "0.2.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "bp-relayers 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "bp-relayers",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "snowbridge-core"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18059ce1b1f0240dfc16711b901d119baaf5c516b2c5f6873bc7ea661d43674"
-dependencies = [
- "bp-relayers 0.22.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "polkadot-parachain-primitives 18.0.0",
- "scale-info",
- "serde",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -22510,7 +18697,7 @@ dependencies = [
  "cliclack",
  "derive_more 2.0.1",
  "email-address-parser",
- "env_logger 0.11.8",
+ "env_logger",
  "path-slash",
  "rayon",
  "soldeer-core",
@@ -22558,38 +18745,15 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 15.0.0",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-metadata-ir 0.6.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d91062b6183f20a6c5fb02d055eeacb4791c8ad32fa1d280c75c0b29aa74acf"
-dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 24.0.0",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "sp-metadata-ir 0.12.0",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-state-machine 0.47.0",
- "sp-trie 41.0.0",
- "sp-version 41.0.0",
+ "sp-api-proc-macro",
+ "sp-core",
+ "sp-externalities",
+ "sp-metadata-ir",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-trie",
+ "sp-version",
  "thiserror 1.0.69",
 ]
 
@@ -22597,21 +18761,6 @@ dependencies = [
 name = "sp-api-proc-macro"
 version = "15.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
-dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8124c25cffbde85d2ef5978fa710bb900d89c368821e04d59040788a0ece3e25"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -22630,21 +18779,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8f2382e7b06f3754d66d781bb57021e415715b48a3a65ea452f9ca7e13ec8"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
+ "sp-core",
+ "sp-io",
 ]
 
 [[package]]
@@ -22662,43 +18798,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-arithmetic"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f4755af7cc57f4a2a830e134b403fc832caa5d93dacb970ffc7ac717f38c40"
-dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-authority-discovery"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00f125cb1ee42d105005efbf0d78191db96420b35393b19ed121151f2db3f26"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -22706,54 +18814,41 @@ name = "sp-block-builder"
 version = "26.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-api 26.0.0",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-block-builder"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c35a7ce8057aa1882cd096863533300ff3805e6fd31eb2c0d25298cec2896"
-dependencies = [
- "sp-api 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bbc12a32427066f7c84621dc6e1a8017c5a2b73ca6fa549c0a79d106bc78e8"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "schnellru",
- "sp-api 38.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-core 38.0.0",
+ "sp-core",
  "sp-database",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a3f4a09ba62631a18bddea0aee8cc7f50f02aeb1b9ffbaa578b0345dbd2867"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-state-machine 0.47.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
 ]
 
@@ -22765,29 +18860,12 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-consensus-slots 0.32.0",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "sp-timestamp 26.0.0",
-]
-
-[[package]]
-name = "sp-consensus-aura"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ae4c25ce19f4b0527d26a2d4225c3ddc1fcf0b4dfc8d1f02f874ecfa64eb7d"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-consensus-slots 0.44.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-timestamp 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -22799,32 +18877,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "sp-timestamp 26.0.0",
-]
-
-[[package]]
-name = "sp-consensus-babe"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e4b6de91c8151b91bd43f9291fbe8f543ca82cbdb19fff71bda6961c6b7802"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-consensus-slots 0.44.0",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-timestamp 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -22835,36 +18894,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-io 30.0.0",
- "sp-keystore 0.34.0",
- "sp-mmr-primitives 26.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sp-consensus-beefy"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e818dbd8d5d6b38d97d2892467e40836e808ff53b593dc6098e6dc8f74631795"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 42.0.0",
- "sp-keystore 0.44.0",
- "sp-mmr-primitives 38.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
+ "sp-io",
+ "sp-keystore",
+ "sp-mmr-primitives",
+ "sp-runtime",
+ "sp-weights",
  "strum 0.26.3",
 ]
 
@@ -22878,29 +18916,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-consensus-grandpa"
-version = "25.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae471cdb1dd297031bdb674e1e99545dc6fc721afcfcf37ab388c60e835fc74"
-dependencies = [
- "finality-grandpa",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -22909,21 +18929,9 @@ version = "0.32.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-consensus-pow"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f2c6c9d346f7829bf9f9fb80bf1c57147df7c1ea44e710a0713cd0490d2aa"
-dependencies = [
- "parity-scale-codec",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -22934,19 +18942,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-timestamp 26.0.0",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5030ea234ed6b31c089df51f9029bd5f8ab9560b83a24133df4b2f966379a3"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp 38.0.0",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -22984,61 +18980,12 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-externalities 0.25.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-storage 19.0.0",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-std",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.4.7",
- "thiserror 1.0.69",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb651e016aa5556f5401596d764566240fe44f7a989dc46ebdefa684e9aeaaa"
-dependencies = [
- "ark-vrf",
- "array-bytes",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections 0.3.2",
- "bs58",
- "dyn-clone",
- "ed25519-zebra",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "paste",
- "primitive-types 0.13.1",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel 0.11.5",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
- "serde",
- "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.30.0",
- "sp-runtime-interface 31.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 22.0.0",
- "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -23054,21 +19001,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core-hashing"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f812cb2dff962eb378c507612a50f1c59f52d92eb97b710f35be3c2346a3cd7"
-dependencies = [
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sp-core-hashing-proc-macro"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24af8075c08ee24cccde21aa3d0d8fb647088deaaf3ceee7cc079f1c7107f51"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing-proc-macro",
 ]
 
 [[package]]
@@ -23088,28 +19025,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch 0.4.0",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale 0.0.12",
- "sp-runtime-interface 24.0.0",
-]
-
-[[package]]
-name = "sp-crypto-ec-utils"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78097c62b28e997efa4942c6a5db3ff00046ac11482aeb5d45b1407edae9579f"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-377-ext",
- "ark-bls12-381 0.4.0",
- "ark-bls12-381-ext",
- "ark-bw6-761",
- "ark-bw6-761-ext",
- "ark-ec 0.4.2",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch 0.4.0",
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale 0.0.12",
- "sp-runtime-interface 31.0.0",
+ "sp-runtime-interface",
 ]
 
 [[package]]
@@ -23123,7 +19039,7 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "sha3",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -23136,18 +19052,7 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "sha3",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-crypto-hashing-proc-macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
-dependencies = [
- "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.104",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -23163,22 +19068,10 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -23198,18 +19091,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cbf059dce180a8bf8b6c8b08b6290fa3d1c7f069a60f1df038ab5dd5fc0ba6"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 22.0.0",
+ "sp-storage",
 ]
 
 [[package]]
@@ -23220,21 +19102,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-genesis-builder"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e16e1046045e47124c09a9c9c03bfd1933926d67512aa1e66b778b81e51f4bb"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -23246,21 +19115,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d91ae44bf5232bff4e1a804b8eda9cecbf56921c0d67699f7b638db4ea1b776"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -23278,41 +19133,14 @@ dependencies = [
  "polkavm-derive 0.26.0",
  "rustversion",
  "secp256k1 0.28.2",
- "sp-core 28.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-externalities 0.25.0",
- "sp-keystore 0.34.0",
- "sp-runtime-interface 24.0.0",
- "sp-state-machine 0.35.0",
- "sp-tracing 16.0.0",
- "sp-trie 29.0.0",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0f8eb3f6c8824549b9482d71516324cf6e2fd650fcc0845d7a4080233898da"
-dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.30.0",
- "sp-keystore 0.44.0",
- "sp-runtime-interface 31.0.0",
- "sp-state-machine 0.47.0",
- "sp-tracing 18.0.0",
- "sp-trie 41.0.0",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-tracing",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -23322,19 +19150,8 @@ name = "sp-keyring"
 version = "31.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sp-keyring"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0152e8b42857f1764a2ce6abda725d8be008423cc054b747c33a69cbc2a3dd7c"
-dependencies = [
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
  "strum 0.26.3",
 ]
 
@@ -23345,30 +19162,8 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63da3f73c67601452dde155804233f76e993802d4b106e33ae7d88577f46b6a"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
-]
-
-[[package]]
-name = "sp-maybe-compressed-blob"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c768c11afbe698a090386876911da4236af199cd38a5866748df4d8628aeff"
-dependencies = [
- "thiserror 1.0.69",
- "zstd 0.12.4",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -23391,37 +19186,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-metadata-ir"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1464c9e76f97c80a8dbccfe3f9fd4be0f25d0cc372efcf8fdf8791619b0998b9"
-dependencies = [
- "frame-metadata 23.0.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
 name = "sp-mixnet"
 version = "0.4.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
-]
-
-[[package]]
-name = "sp-mixnet"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a80557d8156b9f52999eb5cde3cea8e3df02713d11fb045c4507a4dd92141"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -23434,28 +19206,10 @@ dependencies = [
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-runtime 31.0.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-mmr-primitives"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a492ae11f4c220fea20eb5fbcdc788b02085ebd83c9e2e769708b2b58bf96e3"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-ckb-merkle-mountain-range",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-debug-derive",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -23467,23 +19221,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-npos-elections"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db55883feff59ac34d221f97030d1a0b0699ab259838cb28a5ed19d56de40519"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -23491,20 +19231,9 @@ name = "sp-offchain"
 version = "26.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-offchain"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ddad79b8992fe2cc2b285816ae3814a351139c742da924fcf17c23dd1c145"
-dependencies = [
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -23517,24 +19246,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-panic-handler"
-version = "13.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b52e69a577cbfdea62bfaf16f59eb884422ce98f78b5cd8d9bf668776bced1"
-dependencies = [
- "backtrace",
- "regex",
-]
-
-[[package]]
 name = "sp-rpc"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c0d87eb9ee8427d02db43da1a11bba9d65c7fc2f5bc7c13076c557f57692a1"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
- "sp-core 38.0.0",
+ "sp-core",
 ]
 
 [[package]]
@@ -23542,7 +19260,7 @@ name = "sp-runtime"
 version = "31.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "binary-merkle-tree 13.0.0",
+ "binary-merkle-tree",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -23555,43 +19273,13 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-trie 29.0.0",
- "sp-weights 27.0.0",
- "tracing",
- "tuplex",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3992bd6026675946f12fc3c891c863f017a01449a5a15d07656ea1b6503f3ba2"
-dependencies = [
- "binary-merkle-tree 16.0.0",
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 42.0.0",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 41.0.0",
- "sp-weights 33.0.0",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "sp-trie",
+ "sp-weights",
  "tracing",
  "tuplex",
 ]
@@ -23605,32 +19293,12 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive 0.26.0",
- "sp-externalities 0.25.0",
- "sp-runtime-interface-proc-macro 17.0.0",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4820882d8e6e764b98efaeed3a431aa9a0d1738c4adf935fbb4c50113288073"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.30.0",
- "sp-runtime-interface-proc-macro 20.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 22.0.0",
- "sp-tracing 18.0.0",
- "sp-wasm-interface 23.0.0",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
@@ -23648,46 +19316,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04178084ae654b3924934a56943ee73e3562db4d277e948393561b08c3b5b5fe"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "sp-session"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
-]
-
-[[package]]
-name = "sp-session"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860f9c9f4681c99341f8d12640788924f73b92118982638cae0ef2f483e79dd2"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-core 38.0.0",
- "sp-keystore 0.44.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -23699,22 +19338,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-staking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9945ce70bbfb9b1c876f94a81017915bc932a576b8a9735b88aabfa01ea4e5"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -23728,31 +19353,10 @@ dependencies = [
  "parking_lot 0.12.4",
  "rand 0.8.5",
  "smallvec",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-panic-handler 13.0.0",
- "sp-trie 29.0.0",
- "thiserror 1.0.69",
- "tracing",
- "trie-db",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa59c3fdf73700dd3e9dcce503fb15c3ef59dfed3ed34f0eec78d8f5b5d1c45"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "rand 0.8.5",
- "smallvec",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "sp-panic-handler 13.0.2",
- "sp-trie 41.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -23771,47 +19375,16 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.9",
- "sp-api 26.0.0",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-externalities 0.25.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-runtime-interface",
  "thiserror 1.0.69",
  "x25519-dalek",
 ]
-
-[[package]]
-name = "sp-statement-store"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65032d9d068d3a3bf071c799e0a208f2f829c2ee3482d1b2e0992f9cf9397971"
-dependencies = [
- "aes-gcm",
- "curve25519-dalek",
- "ed25519-dalek",
- "hkdf",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sha2 0.10.9",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-core 38.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.30.0",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "thiserror 1.0.69",
- "x25519-dalek",
-]
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
 name = "sp-std"
@@ -23827,20 +19400,7 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3b70ca340e41cde9d2e069d354508a6e37a6573d66f7cc38f11549002f64ec"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -23850,21 +19410,8 @@ source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a2
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57897783f3ae2b0630196f767194d9f753759305a5266fc2e0522e920733df0a"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -23881,35 +19428,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-tracing"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fa3a9161173fa99b4455afc52811eb8251e90ca37a2cbebb8be9c47dc55c00"
-dependencies = [
- "parity-scale-codec",
- "regex",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.20",
-]
-
-[[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "sp-api 26.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "sp-transaction-pool"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec2ce1712ceb1111418ebe3855f017c5d68e954d376d8bf97dcb720a950edc9"
-dependencies = [
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -23920,25 +19444,10 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "sp-transaction-storage-proof"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ac2bb32723c319db70b49fcb678e68412204846600494d3bc0584daff94d7c"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.0.0",
- "sp-inherents 38.0.0",
- "sp-runtime 43.0.0",
- "sp-trie 41.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -23957,35 +19466,9 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "substrate-prometheus-endpoint 0.17.0",
- "thiserror 1.0.69",
- "tracing",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17205dd7df84be66e55a136b5d80dfb6c23806376c0ef5e847ea9344c0478cf"
-dependencies = [
- "ahash",
- "foldhash 0.1.5",
- "hash-db",
- "hashbrown 0.15.4",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 38.0.0",
- "sp-externalities 0.30.0",
- "substrate-prometheus-endpoint 0.17.7",
+ "sp-core",
+ "sp-externalities",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -24002,28 +19485,10 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
- "sp-version-proc-macro 13.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-version"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d7b57b6577ddab5b363c2d6e9d49609749e041ee50e7232ecb413bc1cfa3f"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 43.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version-proc-macro 15.0.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime",
+ "sp-std",
+ "sp-version-proc-macro",
  "thiserror 1.0.69",
 ]
 
@@ -24031,19 +19496,6 @@ dependencies = [
 name = "sp-version-proc-macro"
 version = "13.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
-dependencies = [
- "parity-scale-codec",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sp-version-proc-macro"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cabc8279e835cd9c608d70cb00e693bddec94fe8478e9f3104dad1da5f93ca"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -24061,20 +19513,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "wasmtime 35.0.0",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568979072b49384ef6bbaa5aa1306a91f0b983a4b22c8ef515b601748683b97c"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "wasmtime 8.0.1",
+ "wasmtime",
 ]
 
 [[package]]
@@ -24087,23 +19526,8 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 23.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
-]
-
-[[package]]
-name = "sp-weights"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae0642af5f2dd0b1cddcd06f91c36f7abe0528713e97b6e3c36faf0b8229114"
-dependencies = [
- "bounded-collections 0.3.2",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 28.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -24377,26 +19801,12 @@ name = "staging-parachain-info"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "staging-parachain-info"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cef67f61c821d8b69a7d69b87d24d2b829049e5c2ff1bbfe7d73894e4f1ee8"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -24408,38 +19818,16 @@ dependencies = [
  "bounded-collections 0.3.2",
  "derive-where",
  "environmental",
- "frame-support 28.0.0",
+ "frame-support",
  "hex-literal",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
+ "sp-runtime",
+ "sp-weights",
  "tracing",
- "xcm-procedural 7.0.0",
-]
-
-[[package]]
-name = "staging-xcm"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16708a8ff2bf701090ca8146ad4a0eb8ab00f2a03108f8c889d4eb2eccd7233d"
-dependencies = [
- "array-bytes",
- "bounded-collections 0.3.2",
- "derive-where",
- "environmental",
- "frame-support 42.0.0",
- "hex-literal",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
- "xcm-procedural 11.0.2",
+ "xcm-procedural",
 ]
 
 [[package]]
@@ -24448,46 +19836,21 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "environmental",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-asset-conversion 10.0.0",
- "pallet-transaction-payment 28.0.0",
+ "pallet-asset-conversion",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-executor 7.0.0",
- "tracing",
-]
-
-[[package]]
-name = "staging-xcm-builder"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbadbc3bd1a8142fce70e6979357f2db2590185fd14caddfb4d72cdf08b09f7"
-dependencies = [
- "environmental",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "pallet-asset-conversion 24.0.0",
- "pallet-transaction-payment 42.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 18.0.0",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-executor",
  "tracing",
 ]
 
@@ -24497,38 +19860,17 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "environmental",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
- "tracing",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e3997c812e17ebcdc34fe92ab4c438cbe6647a2fc05ec0a9f8e5d9f3dccf88"
-dependencies = [
- "environmental",
- "frame-benchmarking 42.0.0",
- "frame-support 42.0.0",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 28.0.0",
- "sp-core 38.0.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
  "tracing",
 ]
 
@@ -24709,19 +20051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bip39"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2 0.12.2",
- "schnorrkel 0.11.5",
- "sha2 0.10.9",
- "zeroize",
-]
-
-[[package]]
 name = "substrate-bn"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24736,38 +20065,36 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-support"
-version = "47.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160a9faecc94286f977d68bacd0ca8893e6a978e8365ac70133775e069f3a788"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 42.0.0",
+ "frame-support",
  "jsonrpsee",
  "parity-scale-codec",
  "sc-rpc-api",
  "scale-info",
  "serde",
- "sp-storage 22.0.0",
+ "sp-storage",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1fc331850d24b465655d0c8c1b53d9cf7b960e2c36f063e77fd93e52bf83cc"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "docify",
- "frame-system-rpc-runtime-api 38.0.0",
+ "frame-system-rpc-runtime-api",
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 38.0.0",
- "sp-block-builder 38.0.0",
+ "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -24785,32 +20112,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-prometheus-endpoint"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23e4bc8e910a312820d589047ab683928b761242dbe31dee081fbdb37cbe0be"
-dependencies = [
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "log",
- "prometheus",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "substrate-rpc-client"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a586d661d614be092603e7810415ee8c523d917ac3799eec45a85a3e150606fd"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "async-trait",
  "jsonrpsee",
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime 43.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -24819,16 +20130,15 @@ version = "0.0.0"
 dependencies = [
  "array-bytes",
  "parity-scale-codec",
- "polkadot-sdk 2507.2.0",
+ "polkadot-sdk",
  "scale-info",
  "serde_json",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aee064cabed85bf5e753e8bac1f6302936927c840691461078ad359d12947aa"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
  "build-helper",
  "cargo_metadata 0.15.4",
@@ -24838,7 +20148,7 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker 0.26.0",
  "shlex",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.23",
@@ -24888,10 +20198,47 @@ dependencies = [
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core 0.41.0",
- "subxt-lightclient",
- "subxt-macro",
+ "subxt-lightclient 0.41.0",
+ "subxt-macro 0.41.0",
  "subxt-metadata 0.41.0",
- "subxt-rpcs",
+ "subxt-rpcs 0.41.0",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "subxt"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74791ddeaaa6de42e7cc8a715c83eb73303f513f90af701fd07eb2caad92ed84"
+dependencies = [
+ "async-trait",
+ "derive-where",
+ "either",
+ "frame-metadata 23.0.0",
+ "futures",
+ "hex",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "scale-bits",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subxt-core 0.43.0",
+ "subxt-lightclient 0.43.0",
+ "subxt-macro 0.43.0",
+ "subxt-metadata 0.43.0",
+ "subxt-rpcs 0.43.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -24914,6 +20261,23 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata 0.41.0",
+ "syn 2.0.104",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-codegen"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1728caecd9700391e78cc30dc298221d6f5ca0ea28258a452aa76b0b7c229842"
+dependencies = [
+ "heck 0.5.0",
+ "parity-scale-codec",
+ "proc-macro2",
+ "quote",
+ "scale-info",
+ "scale-typegen",
+ "subxt-metadata 0.43.0",
  "syn 2.0.104",
  "thiserror 2.0.12",
 ]
@@ -24988,7 +20352,24 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light",
+ "smoldot-light 0.16.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-lightclient"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097ef356e534ce0b6a50b95233512afc394347b971a4f929c4830adc52bbc6f"
+dependencies = [
+ "futures",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "smoldot-light 0.17.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -25006,8 +20387,25 @@ dependencies = [
  "proc-macro-error2",
  "quote",
  "scale-typegen",
- "subxt-codegen",
- "subxt-utils-fetchmetadata",
+ "subxt-codegen 0.41.0",
+ "subxt-utils-fetchmetadata 0.41.0",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "subxt-macro"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69516e8ff0e9340a0f21b8398da7f997571af4734ee81deada5150a2668c8443"
+dependencies = [
+ "darling 0.20.11",
+ "parity-scale-codec",
+ "proc-macro-error2",
+ "quote",
+ "scale-typegen",
+ "subxt-codegen 0.43.0",
+ "subxt-metadata 0.43.0",
+ "subxt-utils-fetchmetadata 0.43.0",
  "syn 2.0.104",
 ]
 
@@ -25048,7 +20446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
 dependencies = [
  "derive-where",
- "finito",
  "frame-metadata 20.0.0",
  "futures",
  "hex",
@@ -25059,7 +20456,32 @@ dependencies = [
  "serde",
  "serde_json",
  "subxt-core 0.41.0",
- "subxt-lightclient",
+ "subxt-lightclient 0.41.0",
+ "thiserror 2.0.12",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
+dependencies = [
+ "derive-where",
+ "finito",
+ "frame-metadata 23.0.0",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-core 0.43.0",
+ "subxt-lightclient 0.43.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -25074,13 +20496,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
 dependencies = [
  "base64 0.22.1",
- "bip32",
  "bip39",
  "cfg-if",
  "crypto_secretbox",
  "hex",
  "hmac 0.12.1",
- "keccak-hash",
  "parity-scale-codec",
  "pbkdf2 0.12.2",
  "regex",
@@ -25132,6 +20552,17 @@ name = "subxt-utils-fetchmetadata"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4fb8fd6b16ecd3537a29d70699f329a68c1e47f70ed1a46d64f76719146563"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -25364,12 +20795,6 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
@@ -25433,7 +20858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -25449,30 +20874,14 @@ name = "testnet-parachains-constants"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "cumulus-primitives-core 0.7.0",
- "frame-support 28.0.0",
- "polkadot-core-primitives 7.0.0",
- "rococo-runtime-constants 7.0.0",
+ "cumulus-primitives-core",
+ "frame-support",
+ "polkadot-core-primitives",
+ "rococo-runtime-constants",
  "smallvec",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "westend-runtime-constants 7.0.0",
-]
-
-[[package]]
-name = "testnet-parachains-constants"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea46692599e7a5aaef55d2795f4d35e9859b3d40de9f4a37a9003a3783c635d"
-dependencies = [
- "cumulus-primitives-core 0.20.0",
- "frame-support 42.0.0",
- "polkadot-core-primitives 19.0.0",
- "rococo-runtime-constants 22.0.0",
- "smallvec",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "westend-runtime-constants 22.0.0",
+ "sp-runtime",
+ "staging-xcm",
+ "westend-runtime-constants",
 ]
 
 [[package]]
@@ -25546,9 +20955,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -25556,9 +20965,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -25683,12 +21092,27 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.26.11",
+ "tungstenite 0.27.0",
 ]
 
 [[package]]
@@ -26122,6 +21546,25 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.12",
  "url",
  "utf-8",
 ]
@@ -26143,6 +21586,12 @@ dependencies = [
  "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-arena"
@@ -26814,9 +22263,25 @@ dependencies = [
  "num-traits",
  "smallvec",
  "spin 0.9.8",
- "wasmi_collections",
- "wasmi_core",
+ "wasmi_collections 0.32.3",
+ "wasmi_core 0.32.3",
  "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
+dependencies = [
+ "arrayvec 0.7.6",
+ "multi-stash",
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_collections 0.40.0",
+ "wasmi_core 0.40.0",
+ "wasmi_ir",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
@@ -26831,6 +22296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmi_collections"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
+
+[[package]]
 name = "wasmi_core"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26843,13 +22314,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.102.0"
+name = "wasmi_core"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
 dependencies = [
- "indexmap 1.9.3",
- "url",
+ "downcast-rs",
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core 0.40.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -26887,52 +22376,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f907fdead3153cb9bfb7a93bbd5b62629472dc06dee83605358c64c52ed3dda9"
-dependencies = [
- "anyhow",
- "bincode",
- "cfg-if",
- "indexmap 1.9.3",
- "libc",
- "log",
- "object 0.30.4",
- "once_cell",
- "paste",
- "psm",
- "rayon",
- "serde",
- "target-lexicon 0.12.16",
- "wasmparser 0.102.0",
- "wasmtime-cache",
- "wasmtime-cranelift",
- "wasmtime-environ 8.0.1",
- "wasmtime-jit",
- "wasmtime-runtime",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "wasmtime"
 version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line",
  "anyhow",
  "bitflags 2.9.1",
  "bumpalo",
  "cc",
  "cfg-if",
- "gimli 0.31.1",
+ "gimli",
  "hashbrown 0.15.4",
  "indexmap 2.10.0",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -26941,9 +22402,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
  "wasmparser 0.235.0",
- "wasmtime-environ 35.0.0",
+ "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
  "wasmtime-internal-cranelift",
@@ -26958,110 +22419,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b9daa7c14cd4fa3edbf69de994408d5f4b7b0959ac13fa69d465f6597f810d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86437fa68626fe896e5afc69234bb2b5894949083586535f200385adfd71213"
-dependencies = [
- "anyhow",
- "base64 0.21.7",
- "bincode",
- "directories-next",
- "file-per-thread-logger",
- "log",
- "rustix 0.36.17",
- "serde",
- "sha2 0.10.9",
- "toml 0.5.11",
- "windows-sys 0.45.0",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cefde0cce8cb700b1b21b6298a3837dba46521affd7b8c38a9ee2c869eee04"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.95.1",
- "cranelift-entity 0.95.1",
- "cranelift-frontend 0.95.1",
- "cranelift-native 0.95.1",
- "cranelift-wasm",
- "gimli 0.27.3",
- "log",
- "object 0.30.4",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmparser 0.102.0",
- "wasmtime-cranelift-shared",
- "wasmtime-environ 8.0.1",
-]
-
-[[package]]
-name = "wasmtime-cranelift-shared"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd041e382ef5aea1b9fc78442394f1a4f6d676ce457e7076ca4cb3f397882f8b"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.95.1",
- "cranelift-native 0.95.1",
- "gimli 0.27.3",
- "object 0.30.4",
- "target-lexicon 0.12.16",
- "wasmtime-environ 8.0.1",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990198cee4197423045235bf89d3359e69bd2ea031005f4c2d901125955c949"
-dependencies = [
- "anyhow",
- "cranelift-entity 0.95.1",
- "gimli 0.27.3",
- "indexmap 1.9.3",
- "log",
- "object 0.30.4",
- "serde",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmparser 0.102.0",
- "wasmtime-types",
-]
-
-[[package]]
 name = "wasmtime-environ"
 version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
 dependencies = [
  "anyhow",
- "cpp_demangle 0.4.4",
+ "cpp_demangle",
  "cranelift-bitset",
- "cranelift-entity 0.122.0",
- "gimli 0.31.1",
+ "cranelift-entity",
+ "gimli",
  "indexmap 2.10.0",
  "log",
- "object 0.36.7",
+ "object",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
  "wasm-encoder",
  "wasmparser 0.235.0",
  "wasmprinter",
@@ -27104,21 +22480,21 @@ checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.122.0",
+ "cranelift-codegen",
  "cranelift-control",
- "cranelift-entity 0.122.0",
- "cranelift-frontend 0.122.0",
- "cranelift-native 0.122.0",
- "gimli 0.31.1",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
  "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
  "pulley-interpreter",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
  "thiserror 2.0.12",
  "wasmparser 0.235.0",
- "wasmtime-environ 35.0.0",
+ "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -27174,9 +22550,9 @@ checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.122.0",
+ "cranelift-codegen",
  "log",
- "object 0.36.7",
+ "object",
 ]
 
 [[package]]
@@ -27197,96 +22573,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.122.0",
- "gimli 0.31.1",
- "object 0.36.7",
- "target-lexicon 0.13.3",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
  "wasmparser 0.235.0",
- "wasmtime-environ 35.0.0",
+ "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-jit"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de48df552cfca1c9b750002d3e07b45772dd033b0b206d5c0968496abf31244"
-dependencies = [
- "addr2line 0.19.0",
- "anyhow",
- "bincode",
- "cfg-if",
- "cpp_demangle 0.3.5",
- "gimli 0.27.3",
- "log",
- "object 0.30.4",
- "rustc-demangle",
- "serde",
- "target-lexicon 0.12.16",
- "wasmtime-environ 8.0.1",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-runtime",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "wasmtime-jit-debug"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0554b84c15a27d76281d06838aed94e13a77d7bf604bbbaf548aa20eb93846"
-dependencies = [
- "object 0.30.4",
- "once_cell",
- "rustix 0.36.17",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aecae978b13f7f67efb23bd827373ace4578f2137ec110bbf6a4a7cde4121bbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "wasmtime-runtime"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658cf6f325232b6760e202e5255d823da5e348fdea827eff0a2a22319000b441"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "indexmap 1.9.3",
- "libc",
- "log",
- "mach",
- "memfd",
- "memoffset 0.8.0",
- "paste",
- "rand 0.8.5",
- "rustix 0.36.17",
- "wasmtime-asm-macros",
- "wasmtime-environ 8.0.1",
- "wasmtime-jit-debug",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "wasmtime-types"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f6fffd2a1011887d57f07654dd112791e872e3ff4a2e626aee8059ee17f06f"
-dependencies = [
- "cranelift-entity 0.95.1",
- "serde",
- "thiserror 1.0.69",
- "wasmparser 0.102.0",
 ]
 
 [[package]]
@@ -27437,32 +22731,15 @@ name = "westend-runtime-constants"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-common 7.0.0",
+ "frame-support",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
-]
-
-[[package]]
-name = "westend-runtime-constants"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f995da94ebee2695418202f917bae95f77f5bfbba9033160e233f4b73070b2"
-dependencies = [
- "frame-support 42.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-common 21.0.0",
- "smallvec",
- "sp-core 38.0.0",
- "sp-runtime 43.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -27553,14 +22830,14 @@ checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
- "cranelift-codegen 0.122.0",
- "gimli 0.31.1",
+ "cranelift-codegen",
+ "gimli",
  "regalloc2 0.12.2",
  "smallvec",
- "target-lexicon 0.13.3",
+ "target-lexicon",
  "thiserror 2.0.12",
  "wasmparser 0.235.0",
- "wasmtime-environ 35.0.0",
+ "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
 ]
@@ -28106,7 +23383,7 @@ dependencies = [
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -28123,7 +23400,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.12",
@@ -28142,44 +23419,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "xcm-procedural"
-version = "11.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3d21c65cbf847ae0b1a8e6411b614d269d3108c6c649b039bffcf225e89aa4"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 26.0.0",
- "sp-weights 27.0.0",
- "staging-xcm 7.0.1",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "xcm-runtime-apis"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a280f8647fdf16e3705064d732f0afe49c39e0f5bb0e18878f2c4587751fb89"
-dependencies = [
- "frame-support 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-api 38.0.0",
- "sp-weights 33.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-api",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -28187,42 +23437,20 @@ name = "xcm-simulator"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#277a26585b3d7e38668d5068d2f10ef39051f5d6"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
- "polkadot-core-primitives 7.0.0",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "scale-info",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "staging-xcm 7.0.1",
- "staging-xcm-builder 7.0.0",
- "staging-xcm-executor 7.0.0",
-]
-
-[[package]]
-name = "xcm-simulator"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e552dfed8c3e6e0b94759f695de2c18ded855734d673b036079beeed7b2105a"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "paste",
- "polkadot-core-primitives 19.0.0",
- "polkadot-parachain-primitives 18.0.0",
- "polkadot-primitives 20.0.0",
- "polkadot-runtime-parachains 21.0.1",
- "scale-info",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "staging-xcm 18.0.0",
- "staging-xcm-builder 22.0.0",
- "staging-xcm-executor 21.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -28392,15 +23620,6 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
@@ -28415,16 +23634,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ thiserror = "2"
 
 # allocators
 mimalloc = "0.1"
-tikv-jemallocator = "0.5"
+tikv-jemallocator = "0.6"
 tracy-client = "0.18"
 
 # misc

--- a/crates/anvil-polkadot/Cargo.toml
+++ b/crates/anvil-polkadot/Cargo.toml
@@ -129,8 +129,8 @@ clap_complete = { version = "4" }
 chrono.workspace = true
 clap_complete_fig = "4"
 parity-scale-codec = "3.7.5"
-subxt = "0.41.0"
-subxt-signer = "0.41.0"
+subxt = "0.43.0"
+subxt-signer = "0.43.0"
 tokio-stream = "0.1.17"
 
 [dev-dependencies]

--- a/crates/anvil-polkadot/Cargo.toml
+++ b/crates/anvil-polkadot/Cargo.toml
@@ -20,7 +20,7 @@ path = "bin/main.rs"
 [dependencies]
 # foundry internal
 substrate-runtime = { path = "substrate-runtime" }
-polkadot-sdk = { version = "2507.1", default-features = false, features = [
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master", default-features = false, features = [
     "sc-allocator",
 	"sc-basic-authorship",
 	"sc-block-builder",

--- a/crates/anvil-polkadot/substrate-runtime/Cargo.toml
+++ b/crates/anvil-polkadot/substrate-runtime/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 [dependencies]
 array-bytes = { version = "6.2.2", default-features = false }
 codec = { version = "3.7.5", default-features = false, package = "parity-scale-codec" }
-polkadot-sdk = { version = "2507.1", default-features = false, features = [
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master", default-features = false, features = [
 	"pallet-balances",
 	"pallet-revive",
 	"pallet-sudo",
@@ -27,7 +27,7 @@ scale-info = { version = "2.11.6", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
-polkadot-sdk = { version = "2507.1", default-features = false, optional = true, features = ["substrate-wasm-builder"] }
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master", default-features = false, optional = true, features = ["substrate-wasm-builder"] }
 
 [features]
 default = ["std"]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rand.workspace = true
 snapbox = { version = "0.6", features = ["json", "regex", "term-svg"] }
 tempfile.workspace = true
-subxt = "0.41.0"
+subxt = "0.43.0"
 tokio.workspace = true
 ui_test = "0.29.2"
 


### PR DESCRIPTION
# Ubuntu

- Fix it by installing `clang libclang-dev` which is a new dependency required after https://github.com/paritytech/polkadot-sdk/pull/9644/files.

# MacOS
- Fix it by installing llvm and setting the correct llvm paths.

~I also had temporary disable caching for  `cache-targets` because at is seems to have cache some broken version on macos and continuously using that, I think we should be able to re-enable after merging.~

Used a different prefixed key to force the generation of a new cache.