### PR TITLE
fix DuplicateContract error

### DIFF
--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -499,7 +499,7 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
                         ),
                         _ => None,
                     };
-                    let bump_nonce = BumpNonce::No;
+                    let bump_nonce = BumpNonce::Yes;
 
                     Pallet::<Runtime>::bare_instantiate(
                         origin,


### PR DESCRIPTION
... when running something like this

```
 function testPrank0AfterPrank1(address sender, address origin) public {
        vm.pvm(true);
        Victim victim = new Victim();
        NestedVictim nestedVictim = new NestedVictim(victim);
```

Because nonce does get incremented on create we end up with the same address for 2 different contracts.
