### PR TITLE
Fix the address of the test contract

### DIFF
--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -641,9 +641,9 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
         let (res, _call_trace, prestate_trace) = execute_with_externalities(|externalities| {
             externalities.execute_with(|| {
                 trace::<Runtime, _, _>(|| {
-                    // TODO: Find a way how to do it correctly
-                    // Use pallet-revive origin to bypass EIP-3607.
-                    let origin = OriginFor::<Runtime>::signed(Pallet::<Runtime>::account_id());
+                    let origin = OriginFor::<Runtime>::signed(AccountId::to_fallback_account_id(
+                        &H160::from_slice(input.caller().as_slice()),
+                    ));
                     let evm_value = sp_core::U256::from_little_endian(&input.value().as_le_bytes());
 
                     let (gas_limit, storage_deposit_limit) =


### PR DESCRIPTION
**Summary**
When running the vm_load test in foundry-polkadot, contract creation in PVM mode fails with a BadOrigin error. The root cause is that the test contract address is being incorrectly overwritten with the CREATE2 deployer address during infrastructure setup.

**Symptoms**
Test: vm_load
Error: Contract creation failed: BadOrigin
When: Creating a contract with new Counter(x) after calling vm.pvm(true) to switch to PVM mode
The test contract attempts to create a Counter contract in PVM, but the origin validation fails

**Root Cause of the issue**
The Backend::initialize() function unconditionally sets the test_contract address on every transaction, based on the transaction being executed.

**The Problem Flow**
Test contract deployment (in runner.rs:161):
set_test_contract(address) is called explicitly with the actual test contract address 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496
This happens early because foundry-polkadot needs to know the test contract address to skip PVM mode for test contract operations
CREATE2 deployer deployment (in runner.rs:200):
deploy_create2_deployer() is called, which deploys the CREATE2 factory at 0x4e59b44847b379578588920ca78fbf26c0b4956c (which is DEFAULT_CREATE2_DEPLOYER)
This deployment triggers Backend::initialize()
initialize() calculates the deployed contract address and calls set_test_contract() with 0x4e59b44847b379578588920ca78fbf26c0b4956c
The actual test contract address is now overwritten with the CREATE2 deployer address
