### PR TITLE
fixup warp cheatcode

### DIFF
--- a/crates/forge/tests/cli/revive_vm.rs
+++ b/crates/forge/tests/cli/revive_vm.rs
@@ -194,13 +194,20 @@ import "./test.sol";
 import "./Vm.sol";
 import {console} from "./console.sol";
 
+contract BlockTimestampRevive {
+    function getBlockTimestamp() public view returns (uint256) {
+        return block.timestamp;
+    }
+}
+
 contract Warp is DSTest {
   Vm constant vm = Vm(HEVM_ADDRESS);
 
   function test_Warp() public {
       uint256 original = block.timestamp;
       vm.warp(100);
-      uint256 newValue = block.timestamp;
+      BlockTimestampRevive revive = new BlockTimestampRevive();
+      uint256 newValue = revive.getBlockTimestamp();
       assert(original != newValue);
       assertEq(newValue, 100);
   }

--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -213,7 +213,10 @@ fn set_timestamp(new_timestamp: U256, ecx: Ecx<'_, '_, '_>) {
     // Set timestamp in pallet-revive runtime.
     execute_with_externalities(|externalities| {
         externalities.execute_with(|| {
-            Timestamp::set_timestamp(new_timestamp.try_into().expect("Timestamp exceeds u64"));
+            // Pallet-revive timestamp is in milliseconds, so we convert from seconds.
+            Timestamp::set_timestamp(
+                (new_timestamp * U256::from(1000)).try_into().expect("Timestamp exceeds u64"),
+            );
         })
     });
 }


### PR DESCRIPTION
Timestamp in ethereum is in seconds while the revive timestamp is in seconds, fixing by adjusting the timestamp before setting it.