### PR TITLE
Disable prometheus metrics

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -76,6 +76,30 @@ targets = [t_linux_x86, t_macos, t_windows] if is_pr else [t_linux_x86, t_macos,
 
 config = [
     Case(
+        name="unit",
+        filter="!kind(test)",
+        n_partitions=1,
+        pr_cross_platform=True,
+    ),
+    Case(
+        name="integration",
+        filter="kind(test) & !test(/\\b(issue|ext_integration)|polkadot_localnode/)",
+        n_partitions=3,
+        pr_cross_platform=True,
+    ),
+    Case(
+        name="integration / issue-repros",
+        filter="package(=forge) & test(/\\bissue/)",
+        n_partitions=2,
+        pr_cross_platform=False,
+    ),
+    Case(
+        name="integration / external",
+        filter="package(=forge) & test(/\\bext_integration/)",
+        n_partitions=2,
+        pr_cross_platform=False,
+    ),
+        Case(
         name="integration / polkadot_localnode",
         filter="(package(=cast) | package(=forge)) & test(/polkadot_localnode/)",
         n_partitions=1,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,176 +21,176 @@ jobs:
       profile: default
     secrets: inherit
 
-  # docs:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #     - name: Install protobuf-compiler
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         target: wasm32-unknown-unknown
-  #         components: rust-src
-  #         toolchain: nightly-x86_64-unknown-linux-gnu
-  #     - name: Install clang on ubuntu
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang libclang-dev
-  #     - name: Build documentation
-  #       run: cargo doc --workspace --all-features --no-deps --document-private-items
-  #       env:
-  #         RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
-  #     - name: Deploy documentation
-  #       uses: peaceiris/actions-gh-pages@v3
-  #       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         publish_dir: target/doc
-  #         force_orphan: true
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+          toolchain: nightly-x86_64-unknown-linux-gnu
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+      - name: Build documentation
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc
+          force_orphan: true
 
-  # doctest:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: Install protobuf-compiler
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Install clang on ubuntu
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang libclang-dev
-  #     - uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         target: wasm32-unknown-unknown
-  #         components: rust-src
-  #         toolchain: stable
-  #     - run: cargo test --workspace --doc
+  doctest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+          toolchain: stable
+      - run: cargo test --workspace --doc
 
-  # typos:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: crate-ci/typos@v1
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1
 
-  # clippy:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@clippy
-  #     - name: Install protobuf-compiler
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Install clang on ubuntu
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang libclang-dev
-  #     - uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         target: wasm32-unknown-unknown
-  #         components: rust-src
-  #         toolchain: nightly-x86_64-unknown-linux-gnu
-  #     - run: cargo clippy --workspace --all-targets --all-features --no-deps
-  #       env:
-  #         RUSTFLAGS: -Dwarnings
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@clippy
+      - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+          toolchain: nightly-x86_64-unknown-linux-gnu
+      - run: cargo clippy --workspace --all-targets --all-features
+        env:
+          RUSTFLAGS: -Dwarnings
 
-  # rustfmt:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #       with:
-  #         components: rustfmt
-  #     - run: cargo fmt --all --check
+  rustfmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
 
-  # forge-fmt:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: Install protobuf-compiler
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Install clang on ubuntu
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang libclang-dev
-  #     - name: forge fmt
-  #       shell: bash
-  #       run: ./.github/scripts/format.sh --check
+  forge-fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+      - name: forge fmt
+        shell: bash
+        run: ./.github/scripts/format.sh --check
 
-  # crate-checks:
-  #   runs-on: parity-large-new
-  #   timeout-minutes: 90
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install clang and zip on ubuntu
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y clang libclang-dev zip
-  #     - name: Install build-essential for tikv-jemalloc-sys
-  #       run: |
-  #         sudo apt-get install -y build-essential
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         cache-on-failure: true
-  #     - uses: taiki-e/install-action@cargo-hack
-  #     - name: Install protobuf-compiler
-  #       uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         target: wasm32-unknown-unknown
-  #         components: rust-src
-  #         toolchain: stable
-  #     # Exclude substrate-runtime because it can only be compiled for wasm32 without the std feature.
-  #     # It's anyway compiled without std when building anvil-polkadot (by the wasm builder).
-  #     - run: cargo hack check --each-feature --exclude-features isolate-by-default --exclude substrate-runtime
-  #     # Add another step for running cargo check on substrate runtime (without excluding the default std feature)
-  #     - run: cargo hack check -p substrate-runtime --each-feature --exclude-no-default-features
+  crate-checks:
+    runs-on: parity-large-new
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install clang and zip on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev zip
+      - name: Install build-essential for tikv-jemalloc-sys
+        run: |
+          sudo apt-get install -y build-essential
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@cargo-hack
+      - name: Install protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+          components: rust-src
+          toolchain: stable
+      # Exclude substrate-runtime because it can only be compiled for wasm32 without the std feature.
+      # It's anyway compiled without std when building anvil-polkadot (by the wasm builder).
+      - run: cargo hack check --each-feature --exclude-features isolate-by-default --exclude substrate-runtime
+      # Add another step for running cargo check on substrate runtime (without excluding the default std feature)
+      - run: cargo hack check -p substrate-runtime --each-feature --exclude-no-default-features
 
-  # deny:
-  #   # Copy of ithacaxyz/ci/.github/workflows/deny.yml@main but without failing the CI
-  #   name: cargo deny check
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: nightly
-  #     - name: Install cargo-deny
-  #       uses: taiki-e/install-action@cargo-deny
-  #     - name: Run cargo deny
-  #       run: cargo deny --all-features check all
+  deny:
+    # Copy of ithacaxyz/ci/.github/workflows/deny.yml@main but without failing the CI
+    name: cargo deny check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+      - name: Run cargo deny
+        run: cargo deny --all-features check all
 
   ci-success:
     runs-on: ubuntu-latest
     if: always()
     needs:
       - nextest
-      # - docs
-      # - doctest
-      # - clippy
-      # - rustfmt
-      # - forge-fmt
-      # - crate-checks
+      - docs
+      - doctest
+      - clippy
+      - rustfmt
+      - forge-fmt
+      - crate-checks
     timeout-minutes: 60
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
Fix port conflicts in polkadot_localnode tests by disabling Prometheus metrics endpoint in substrate-node and eth-proxy.