### PR TITLE
fix etch in test contract constructor

### DIFF
--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -206,6 +206,9 @@ fn etch_call(target: &Address, new_runtime_code: &Bytes, ecx: Ecx<'_, '_, '_>) -
     let origin_address = H160::from_slice(ecx.tx.caller.as_slice());
     let origin_account = AccountId::to_fallback_account_id(&origin_address);
 
+    let target_address = H160::from_slice(target.as_slice());
+    let target_account = AccountId::to_fallback_account_id(&target_address);
+
     execute_with_externalities(|externalities| {
         externalities.execute_with(|| {
             let code = new_runtime_code.to_vec();
@@ -222,16 +225,21 @@ fn etch_call(target: &Address, new_runtime_code: &Bytes, ecx: Ecx<'_, '_, '_>) -
             .0;
 
             let mut contract_info = if let Some(contract_info) =
-                AccountInfo::<Runtime>::load_contract(&H160::from_slice(target.as_slice()))
+                AccountInfo::<Runtime>::load_contract(&target_address)
             {
                 contract_info
             } else {
-                ContractInfo::<Runtime>::new(
-                    &origin_address,
-                    System::account_nonce(origin_account),
+                let contract_info = ContractInfo::<Runtime>::new(
+                    &target_address,
+                    System::account_nonce(target_account),
                     *contract_blob.code_hash(),
                 )
-                .map_err(|_| <&str as Into<Error>>::into("Could not create contract info"))?
+                .map_err(|err| {
+                    tracing::error!("Could not create contract info: {:?}", err);
+                    <&str as Into<Error>>::into("Could not create contract info")
+                })?;
+                System::inc_account_nonce(AccountId::to_fallback_account_id(&target_address));
+                contract_info
             };
             contract_info.code_hash = *contract_blob.code_hash();
             AccountInfo::<Runtime>::insert_contract(


### PR DESCRIPTION
The constructor of the test contract could be running vm.etch before we select revive, like here https://github.com/balancer/balancer-v3-monorepo/blob/8ec66211456909e8c72c00c4c094aef4d03894c3/pkg/vault/test/foundry/utils/Permit2Helpers.sol#L18, because TestContract is Permit2Helpers.

So, the etched bytecode never gets uploaded in pallet-revive, overcome this obstacle by making the etched account persistent and migrate the account and its bytecode even if we don't find it in the dual-compiled contracts.