### PR TITLE
fix: add endowed substrate account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "anvil-core",
  "anvil-rpc",
  "anvil-server",
+ "array-bytes",
  "assert_matches",
  "async-trait",
  "axum",

--- a/crates/anvil-polkadot/Cargo.toml
+++ b/crates/anvil-polkadot/Cargo.toml
@@ -26,7 +26,8 @@ secp256k1 = { version = "0.28.0", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false }
 sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master", default-features = false }
 polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "master", default-features = false, features = [
-    "sc-allocator",
+    "parachains-common",
+	"sc-allocator",
 	"sc-basic-authorship",
 	"sc-block-builder",
 	"sc-chain-spec",
@@ -60,6 +61,7 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch 
 	"sp-core-hashing",
 	"sp-core-hashing-proc-macro",
 	"sp-database",
+	"sp-keyring",
 	"sp-panic-handler",
 	"sp-rpc",
 	"std",
@@ -118,6 +120,7 @@ async-trait.workspace = true
 futures-timer = { version = "3.0.3" }
 
 # misc
+array-bytes = "6.2.2"
 flate2 = "1.0"
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/anvil-polkadot/src/substrate_node/genesis.rs
+++ b/crates/anvil-polkadot/src/substrate_node/genesis.rs
@@ -9,11 +9,13 @@ use alloy_primitives::{Address, U256};
 use codec::Encode;
 use polkadot_sdk::{
     pallet_revive::{evm::Account, genesis::ContractData},
+    parachains_common::Balance,
     sc_chain_spec::{BuildGenesisBlock, resolve_state_version_from_wasm},
     sc_client_api::{BlockImportOperation, backend::Backend},
     sc_executor::RuntimeVersionOf,
     sp_blockchain,
     sp_core::{self, H160, storage::Storage},
+    sp_keyring::Sr25519Keyring,
     sp_runtime::{
         BuildStorage, FixedU128,
         traits::{Block as BlockT, Hash as HashT, HashingFor, Header as HeaderT},
@@ -24,6 +26,8 @@ use serde_json::{Value, json};
 use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
 use substrate_runtime::{WASM_BINARY, constants::NATIVE_TO_ETH_RATIO};
 use subxt_signer::eth::Keypair;
+
+pub const DOLLARS: Balance = 1_000_000_000_000;
 
 /// Genesis settings
 #[derive(Clone, Debug, Default)]
@@ -91,6 +95,8 @@ pub struct ReviveGenesisAccount {
 }
 
 impl GenesisConfig {
+    pub const ENDOWMENT: Balance = 1_000_000_000_000_001 * DOLLARS;
+
     pub fn as_storage_key_value(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
         let mut aura_authority_id = [0xEE; 32];
         aura_authority_id[..20].copy_from_slice(
@@ -154,7 +160,25 @@ impl GenesisConfig {
                 })
                 .collect::<Vec<_>>(),
         );
+
+        let well_known_accounts = || {
+            Sr25519Keyring::well_known()
+                .map(|k| k.to_account_id())
+                .chain([
+                    // subxt_signer::eth::dev::alith()
+                    array_bytes::hex_n_into_unchecked(
+                    "f24ff3a9cf04c71dbc94d0b566f7a27b94566caceeeeeeeeeeeeeeeeeeeeeeee",
+                )])
+                .collect::<Vec<_>>()
+        };
+
         json!({
+            "balances": {
+                "balances": well_known_accounts()
+                    .into_iter()
+                    .map(|id| (id, Self::ENDOWMENT))
+                    .collect::<Vec<_>>()
+            },
             "revive": {
                 "accounts": revive_genesis_accounts,
             },


### PR DESCRIPTION
### Description

Uploading factory deps fails because `@parity/hardhat-polkadot` uses Alice to upload the required bytecode. But since there is no balance allocated to Alice's substrate account, the tx fails due to insufficient funds.