### PR TITLE
Transient storage issue

### DIFF
--- a/crates/forge/tests/it/revive/mod.rs
+++ b/crates/forge/tests/it/revive/mod.rs
@@ -8,4 +8,5 @@ pub mod cheat_mock_functions;
 pub mod cheat_prank;
 pub mod cheat_store;
 pub mod migration;
+pub mod transient_storage;
 pub mod tx_gas_price;

--- a/crates/forge/tests/it/revive/transient_storage.rs
+++ b/crates/forge/tests/it/revive/transient_storage.rs
@@ -1,0 +1,16 @@
+use crate::{config::*, test_helpers::TEST_DATA_REVIVE};
+use foundry_test_utils::Filter;
+use revive_strategy::ReviveRuntimeMode;
+use revm::primitives::hardfork::SpecId;
+use rstest::rstest;
+
+#[rstest]
+#[case::pvm(ReviveRuntimeMode::Pvm)]
+#[case::evm(ReviveRuntimeMode::Evm)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transient_storage(#[case] runtime_mode: ReviveRuntimeMode) {
+    let runner: forge::MultiContractRunner = TEST_DATA_REVIVE.runner_revive(runtime_mode);
+    let filter = Filter::new("testTransientStoragePersistence", "TransientStorage", ".*/revive/.*");
+
+    TestConfig::with_filter(runner, filter).spec_id(SpecId::PRAGUE).should_fail().run().await;
+}

--- a/testdata/default/revive/TransientStorage.t.sol
+++ b/testdata/default/revive/TransientStorage.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+import "../../default/logs/console.sol";
+
+/**
+ * @title Minimal reproducer for foundry-polkadot transient storage bug
+ * @dev Demonstrates that transient storage is incorrectly cleared between external calls
+ */
+contract Counter {
+    function increment() external {
+        assembly {
+            let value := tload(0)
+            tstore(0, add(value, 1))
+        }
+    }
+
+    function get() external view returns (uint256 value) {
+        assembly {
+            value := tload(0)
+        }
+    }
+}
+
+contract TransientStorage is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    Counter counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    /**
+     * @dev This test FAILS in foundry-polkadot
+     * Expected: counter.get() returns 1
+     * Actual: counter.get() returns 0
+     *
+     * The bug: transient storage is cleared between the two external calls
+     * According to EIP-1153, transient storage should persist for the entire transaction
+     */
+    function testTransientStoragePersistence() public {
+        // Store value 1 in transient storage
+        counter.increment();
+
+        // This should return 1, but returns 0 in foundry-polkadot
+        uint256 value = counter.get();
+
+        assertEq(value, 1, "Transient storage should persist across external calls");
+    }
+}


### PR DESCRIPTION
DO NOT MERGE
it just shows the issue in polkadot-foundry
pallet-revive do not share the stack with REVM, so the transient storage state is lost