### PR TITLE
fix: don't panic if connection is reset before sending the response

### DIFF
--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -163,7 +163,9 @@ impl ApiServer {
         while let Some(msg) = self.req_receiver.next().await {
             let resp = self.execute(msg.req).await;
 
-            msg.resp_sender.send(resp).expect("Dropped receiver");
+            if let Err(resp) = msg.resp_sender.send(resp) {
+                node_info!("Request was cancelled before sending the response: {:?}", resp);
+            }
         }
     }
 


### PR DESCRIPTION
Issue identified while testing with `cast` commands.
It happens that cast returns and terminates the connection to anvil before the response is sent. Axum terminates the future which was creating the response receiver so the api server was failing to send back the response since the receiver was dropped.

Easy fix: just don't panic in these cases. The rest of the commit is just cosmetic: making a function private and removing an unused function