### PR TITLE
add eip191 prefix to eth_sign and personal_sign

### DIFF
--- a/crates/anvil-polkadot/src/api_server/signer.rs
+++ b/crates/anvil-polkadot/src/api_server/signer.rs
@@ -3,8 +3,7 @@ use crate::api_server::{
     revive_conversions::ReviveAddress,
 };
 use alloy_dyn_abi::TypedData;
-use alloy_primitives::Address;
-use alloy_primitives::utils::eip191_hash_message;
+use alloy_primitives::{Address, utils::eip191_hash_message};
 use polkadot_sdk::pallet_revive::evm::{Account, TransactionSigned, TransactionUnsigned};
 use std::collections::HashMap;
 use subxt::utils::H160;


### PR DESCRIPTION
Closes #470
This PR adds support for [EIP-191](https://eips.ethereum.org/EIPS/eip-191?utm_source=chatgpt.com) by prepending messages to be signed with the standard Ethereum prefix:
```
"\x19Ethereum Signed Message:\n" + len(message)
```
This affects the following RPC methods: `eth_sign` and `personal_sign`.