### PR TITLE
fix: wait for tx to be finalized

### DIFF
--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -766,7 +766,49 @@ impl ApiServer {
     async fn send_raw_transaction(&self, transaction: Bytes) -> Result<H256> {
         let hash = H256(keccak_256(&transaction.0));
         let call = subxt_client::tx().revive().eth_transact(transaction.0);
-        self.eth_rpc_client.submit(call).await?;
+        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
+
+        self.eth_rpc_client.submit(call).await.map_err(|err| {
+            node_info!("send_raw_transaction ethereum_hash: {hash:?} failed: {err:?}");
+            err
+        })?;
+
+        node_info!("send_raw_transaction with hash: {hash:?}");
+
+        // Wait for the transaction to be included in a block if automine is enabled
+        if let Some(mut receiver) = receiver {
+            if let Err(err) = tokio::time::timeout(Duration::from_millis(1000), async {
+                let mut block_number = 0u64;
+				loop {
+					if let Ok(block_hash) = receiver.recv().await {
+						let Ok(Some(block)) = self.eth_rpc_client.block_by_hash(&block_hash).await else {
+							node_info!( "Could not find the block with the received hash: {hash:?}.");
+							continue
+						};
+						let Some(evm_block) = self.eth_rpc_client.evm_block(block, false).await else {
+							node_info!( "Failed to get the EVM block for substrate block with hash: {hash:?}");
+							continue
+						};
+						if evm_block.transactions.contains_tx(hash) {
+							node_info!( "{hash:} was included in a block");
+							block_number= evm_block.number.as_u64();
+                            self.mining_engine.mine(None, None).await;
+                            continue;
+						}
+                        if evm_block.number.as_u64().gt(&block_number) {
+							node_info!( "block {block_number:} corresponding to {hash:} has been finalized");
+                            break
+                        }
+					}
+				}
+			})
+			.await
+			{
+				node_info!( "timeout waiting for new block: {err:?}");
+			}
+        }
+
+        node_info!("send_raw_transaction hash: {hash:?}");
         Ok(hash)
     }
 


### PR DESCRIPTION
### Description

OZ tests were failing with `Priority is too low` errors, since anvil-polkadot waits for tx to be in the block but just that doesn't update the nonce, which causes the runner to keep reusing the same nonce.

### Reproduction steps
* Build `anvil-polkadot`
* `git clone git@github.com:OpenZeppelin/openzeppelin-contracts.git`
* `git checkout v5.5.0`
* `npm i --save-dev @parity/hardhat-polkadot`
* Update the hardhat.config file.
* `npm i`
* `npx hardhat test`

`hardhat.config.ts`

```ts
/// ENVVAR
// - COMPILER:      compiler version (default: 0.8.27)
// - SRC:           contracts folder to compile (default: contracts)
// - RUNS:          number of optimization runs (default: 200)
// - IR:            enable IR compilation (default: false)
// - COVERAGE:      enable coverage report (default: false)
// - GAS:           enable gas report (default: false)
// - COINMARKETCAP: coinmarketcap api key for USD value in gas report
// - CI:            output gas report to file instead of stdout

const fs = require('fs');
const path = require('path');

const { argv } = require('yargs/yargs')()
  .env('')
  .options({
    // Compilation settings
    compiler: {
      alias: 'compileVersion',
      type: 'string',
      default: '0.8.27',
    },
    src: {
      alias: 'source',
      type: 'string',
      default: 'contracts',
    },
    runs: {
      alias: 'optimizationRuns',
      type: 'number',
      default: 200,
    },
    ir: {
      alias: 'enableIR',
      type: 'boolean',
      default: false,
    },
    evm: {
      alias: 'evmVersion',
      type: 'string',
      default: 'prague',
    },
    // Extra modules
    coverage: {
      type: 'boolean',
      default: false,
    },
    gas: {
      alias: 'enableGasReport',
      type: 'boolean',
      default: false,
    },
    coinmarketcap: {
      alias: 'coinmarketcapApiKey',
      type: 'string',
    },
  });

require('@parity/hardhat-polkadot');
require('@nomicfoundation/hardhat-chai-matchers');
require('@nomicfoundation/hardhat-ethers');
require('hardhat-exposed');
require('hardhat-gas-reporter');
require('hardhat-ignore-warnings');
require('hardhat-predeploy');
require('solidity-coverage');
require('solidity-docgen');

for (const f of fs.readdirSync(path.join(__dirname, 'hardhat'))) {
  require(path.join(__dirname, 'hardhat', f));
}

/**
 * @type import('hardhat/config').HardhatUserConfig
 */
module.exports = {
  solidity: {
    version: argv.compiler,
    settings: {
      optimizer: {
        enabled: true,
        runs: argv.runs,
      },
      evmVersion: argv.evm,
      viaIR: argv.ir,
      outputSelection: { '*': { '*': ['storageLayout'] } },
    },
  },
  warnings: {
    'contracts-exposed/**/*': {
      'code-size': 'off',
      'initcode-size': 'off',
    },
    '*': {
      'unused-param': !argv.coverage, // coverage causes unused-param warnings
      'transient-storage': false,
      default: 'error',
    },
  },
  networks: {
    hardhat: {
      polkadot: {
        target: "evm"
      },
      nodeConfig: {
        useAnvil: true,
        nodeBinaryPath: 'path/to/anvil',
        dev: true,
        consensus: {
          seal: "instant-seal",
        },
        rpcPort: 8000,
      },
      adapterConfig: {
        adapterBinaryPath: '.',
        dev: true,
      },
    },
    localNode: {
      polkadot: {
        target: "evm",
      },
      url: "http://127.0.0.1:8545"
    }
  },
  resolc: {
    version: "0.5.0",
  },
  exposed: {
    imports: true,
    initializers: true,
    exclude: ['vendor/**/*', '**/*WithInit.sol'],
  },
  gasReporter: {
    enabled: argv.gas,
    showMethodSig: true,
    includeBytecodeInJSON: true,
    currency: 'USD',
    coinmarketcap: argv.coinmarketcap,
  },
  paths: {
    sources: argv.src,
    artifacts: "artifacts-pvm",
    cache: "cache-pvm",
  },
  docgen: require('./docs/config'),
};
```
Previous behaviour:

```sh
  5585 passing (3h)
  1 pending
  779 failing
```

Current behaviour:

```sh
  6298 passing (26m)
  82 pending
  587 failing
```
