### PR TITLE
Add warning when overflow happens

### DIFF
--- a/crates/anvil-polkadot/tests/it/state_injector.rs
+++ b/crates/anvil-polkadot/tests/it/state_injector.rs
@@ -804,12 +804,9 @@ async fn test_set_immutable_storage() {
     ));
 
     // Verify initial immutable value
-    let call_tx = TransactionRequest::default()
-        .from(alith_addr)
-        .to(contract_address)
-        .input(TransactionInput::both(
-            ImmutableStorage::getImmutableValueCall {}.abi_encode().into(),
-        ));
+    let call_tx = TransactionRequest::default().from(alith_addr).to(contract_address).input(
+        TransactionInput::both(ImmutableStorage::getImmutableValueCall {}.abi_encode().into()),
+    );
     let result = unwrap_response::<Bytes>(
         node.eth_rpc(EthRequest::EthCall(call_tx.into(), None, None, None)).await.unwrap(),
     )
@@ -820,12 +817,9 @@ async fn test_set_immutable_storage() {
     );
 
     // Verify initial immutable address
-    let call_tx = TransactionRequest::default()
-        .from(alith_addr)
-        .to(contract_address)
-        .input(TransactionInput::both(
-            ImmutableStorage::getImmutableAddressCall {}.abi_encode().into(),
-        ));
+    let call_tx = TransactionRequest::default().from(alith_addr).to(contract_address).input(
+        TransactionInput::both(ImmutableStorage::getImmutableAddressCall {}.abi_encode().into()),
+    );
     let result = unwrap_response::<Bytes>(
         node.eth_rpc(EthRequest::EthCall(call_tx.into(), None, None, None)).await.unwrap(),
     )
@@ -842,28 +836,20 @@ async fn test_set_immutable_storage() {
         Account::from(subxt_signer::eth::dev::charleth()).address(),
     ));
 
-    let immutables = vec![
-        Bytes::from(new_value.abi_encode()),
-        Bytes::from(new_address.abi_encode()),
-    ];
+    let immutables =
+        vec![Bytes::from(new_value.abi_encode()), Bytes::from(new_address.abi_encode())];
 
     unwrap_response::<()>(
-        node.eth_rpc(EthRequest::SetImmutableStorageAt(
-            contract_address,
-            immutables,
-        ))
-        .await
-        .unwrap(),
+        node.eth_rpc(EthRequest::SetImmutableStorageAt(contract_address, immutables))
+            .await
+            .unwrap(),
     )
     .unwrap();
 
     // Verify new immutable value
-    let call_tx = TransactionRequest::default()
-        .from(alith_addr)
-        .to(contract_address)
-        .input(TransactionInput::both(
-            ImmutableStorage::getImmutableValueCall {}.abi_encode().into(),
-        ));
+    let call_tx = TransactionRequest::default().from(alith_addr).to(contract_address).input(
+        TransactionInput::both(ImmutableStorage::getImmutableValueCall {}.abi_encode().into()),
+    );
     let result = unwrap_response::<Bytes>(
         node.eth_rpc(EthRequest::EthCall(call_tx.into(), None, None, None)).await.unwrap(),
     )
@@ -874,12 +860,9 @@ async fn test_set_immutable_storage() {
     );
 
     // Verify new immutable address
-    let call_tx = TransactionRequest::default()
-        .from(alith_addr)
-        .to(contract_address)
-        .input(TransactionInput::both(
-            ImmutableStorage::getImmutableAddressCall {}.abi_encode().into(),
-        ));
+    let call_tx = TransactionRequest::default().from(alith_addr).to(contract_address).input(
+        TransactionInput::both(ImmutableStorage::getImmutableAddressCall {}.abi_encode().into()),
+    );
     let result = unwrap_response::<Bytes>(
         node.eth_rpc(EthRequest::EthCall(call_tx.into(), None, None, None)).await.unwrap(),
     )

--- a/crates/anvil-polkadot/tests/it/utils.rs
+++ b/crates/anvil-polkadot/tests/it/utils.rs
@@ -465,16 +465,12 @@ fn load_contract_json(name: &str) -> Value {
     let contract_path =
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("test-data/{name}.json"));
 
-    serde_json::from_reader(std::io::BufReader::new(
-        std::fs::File::open(contract_path).unwrap(),
-    ))
-    .unwrap()
+    serde_json::from_reader(std::io::BufReader::new(std::fs::File::open(contract_path).unwrap()))
+        .unwrap()
 }
 
 fn decode_hex_field(json: &Value, field: &str) -> Option<Vec<u8>> {
-    json.get(field)
-        .and_then(|v| v.as_str())
-        .map(|s| hex::decode(s).unwrap())
+    json.get(field).and_then(|v| v.as_str()).map(|s| hex::decode(s).unwrap())
 }
 
 pub fn get_contract_code(name: &str) -> ContractCode {

--- a/crates/revive-strategy/src/cheatcodes/mod.rs
+++ b/crates/revive-strategy/src/cheatcodes/mod.rs
@@ -355,10 +355,8 @@ impl CheatcodeInspectorStrategyRunner for PvmCheatcodeInspectorStrategyRunner {
             }
             t if using_revive && is::<rollCall>(t) => {
                 let &rollCall { newHeight } = cheatcode.as_any().downcast_ref().unwrap();
-                let clamped_height = ctx.externalities.roll(
-                    newHeight,
-                    &mut *ccx.ecx.journaled_state.database,
-                );
+                let clamped_height =
+                    ctx.externalities.roll(newHeight, &mut *ccx.ecx.journaled_state.database);
 
                 rollCall { newHeight: clamped_height }.dyn_apply(ccx, executor)
             }
@@ -430,7 +428,8 @@ impl CheatcodeInspectorStrategyRunner for PvmCheatcodeInspectorStrategyRunner {
 
                 ctx.externalities.set_blockhash(clamped_block_number.to(), blockHash);
 
-                setBlockhashCall { blockNumber: clamped_block_number, blockHash }.dyn_apply(ccx, executor)
+                setBlockhashCall { blockNumber: clamped_block_number, blockHash }
+                    .dyn_apply(ccx, executor)
             }
             t if using_revive && is::<etchCall>(t) => {
                 let etchCall { target, newRuntimeBytecode } =
@@ -1247,7 +1246,7 @@ impl foundry_cheatcodes::CheatcodeInspectorStrategyExt for PvmCheatcodeInspector
         }
 
         tracing::info!("running call on pallet-revive with {} {:#?}", ctx.runtime_mode, call);
-        
+
         let u128_max: U256 = U256::from(u128::MAX);
         let call_value = call.call_value();
         if call_value > u128_max {

--- a/crates/revive-strategy/src/state.rs
+++ b/crates/revive-strategy/src/state.rs
@@ -160,12 +160,9 @@ impl TestEnv {
         database: &mut DB,
     ) -> U256 {
         let block_num_u64 = new_height.saturating_to::<u64>();
-        let prev_block_hash = database
-            .block_hash(block_num_u64.saturating_sub(1))
-            .unwrap_or_default();
-        let current_block_hash = database
-            .block_hash(block_num_u64)
-            .unwrap_or_default();
+        let prev_block_hash =
+            database.block_hash(block_num_u64.saturating_sub(1)).unwrap_or_default();
+        let current_block_hash = database.block_hash(block_num_u64).unwrap_or_default();
 
         self.set_block_number(new_height, prev_block_hash, current_block_hash)
     }
@@ -295,8 +292,7 @@ impl TestEnv {
             amount
         };
 
-        let amount_pvm =
-            sp_core::U256::from_little_endian(&clamped_amount.as_le_bytes());
+        let amount_pvm = sp_core::U256::from_little_endian(&clamped_amount.as_le_bytes());
 
         self.0.lock().unwrap().externalities.execute_with(|| {
             let h160_addr = H160::from_slice(address.as_slice());


### PR DESCRIPTION
When an overflow happens on the block timestamp, block number, or balance while using cheatcodes, a warning is triggered and the value is rounded to the maximum possible value. For `CALL` and `CREATE` opcodes with an excessively high balance, a revert is triggered.