### PR TITLE
[foundryup] Fix refspec when fetching using `--commit` and `--branch`

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -350,7 +350,7 @@ main() {
 
     # Force checkout, discarding any local changes
     cd "$REPO_PATH"
-    ensure git fetch origin "${FOUNDRYUP_BRANCH}:remotes/origin/${FOUNDRYUP_BRANCH}"
+    ensure git fetch origin "refs/heads/${FOUNDRYUP_BRANCH}:refs/remotes/origin/${FOUNDRYUP_BRANCH}"
     ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
 
     # Create custom version based on the install method, e.g.:


### PR DESCRIPTION
## Motivation

`foundryup-polkadot --branch <name>` and `--commit <sha>` fail whenever the branch name that the script tries to fetch also exists as a tag. This causes the source refname in the fetch to become ambiguous.

Currently, there exists a `master` tag and that is the one that [will be selected](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-refnameegmasterheadsmasterrefsheadsmaster) when trying to fetch the `master` branch.

* `foundryup-polkadot` version: 1.4.0

(Side note: The `master` tag may have been created on a release [workflow dispatch](https://github.com/paritytech/foundry-polkadot/blob/eacd434461b05ca6981330a5e5bbf8710856834d/.github/workflows/release.yml#L51).)

## Solution

This PR fully qualifies both sides of the refspec which disambiguates the fetch even if a same-named tag exists.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
